### PR TITLE
Fix mistake in last commit.

### DIFF
--- a/System/Win32/Security.hsc
+++ b/System/Win32/Security.hsc
@@ -1,3 +1,10 @@
+{-# OPTIONS_GHC -w #-}
+-- The above warning supression flag is a temporary kludge.
+-- While working on this module you are encouraged to remove it and fix
+-- any warnings in the module. See
+--     http://hackage.haskell.org/trac/ghc/wiki/WorkingConventions#Warnings
+-- for details
+
 #if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
 #endif
@@ -14,13 +21,6 @@
 -- FFI-bindings to interact with Win32 Security
 --
 -----------------------------------------------------------------------------
-
-{-# OPTIONS_GHC -w #-}
--- The above warning supression flag is a temporary kludge.
--- While working on this module you are encouraged to remove it and fix
--- any warnings in the module. See
---     http://hackage.haskell.org/trac/ghc/wiki/WorkingConventions#Warnings
--- for details
 
 module System.Win32.Security ( 
         -- * Types


### PR DESCRIPTION
Hi Bryan,

Sadly Ian pointed out a mistake in my patch. GHC 6.12 and earlier stop
parsing pragmas once they encounter a CPP directive. So I needed to
change the layout from:
# if **GLASGOW_HASKELL** >= 701

{-# LANGUAGE Trustworthy #-}
# endif

{-# LANGUAGE ... #-}
{-# OPTIONS_GHC ... #-}

to this layout:

{-# LANGUAGE ... #-}
{-# OPTIONS_GHC ... #-}
# if **GLASGOW_HASKELL** >= 701

{-# LANGUAGE Trustworthy #-}
# endif

This is a patch that changes to the later layout to fix compilation of Win32 with GHC 6.12 and earlier.

Thanks!
