### PR TITLE
regSetStringValue should account for null terminator in value string

### DIFF
--- a/System/Win32/Registry.hsc
+++ b/System/Win32/Registry.hsc
@@ -497,7 +497,7 @@ type RegValueType = DWORD
 regSetStringValue :: HKEY -> String -> String -> IO ()
 regSetStringValue hk key val =
   withTString val $ \ v ->
-  regSetValueEx hk key rEG_SZ v (length val * sizeOf (undefined::TCHAR))
+  regSetValueEx hk key rEG_SZ v ((1+length val) * sizeOf (undefined::TCHAR))
 
 regSetValueEx :: HKEY -> String -> RegValueType -> LPTSTR -> Int -> IO ()
 regSetValueEx key subkey ty value value_len =


### PR DESCRIPTION
Shouldn't regSetStringValue account for the NULL terminator in the value string? 

MSDN indicates that "REG_SZ specifies a null-terminated Unicode string", and for the corresponding cbData "This parameter must include the size of the terminating null character".

http://msdn.microsoft.com/en-us/library/windows/desktop/ms724923(v=vs.85).aspx
