### PR TITLE
Add support for GetFileAttributesEx

### DIFF
--- a/System/Win32/File.hsc
+++ b/System/Win32/File.hsc
@@ -462,6 +462,12 @@ getFileAttributes name =
 foreign import WINDOWS_CCONV unsafe "windows.h GetFileAttributesW"
   c_GetFileAttributes :: LPCTSTR -> IO FileAttributeOrFlag
 
+getFileAttributesExStandard :: String -> IO WIN32_FILE_ATTRIBUTE_DATA
+getFileAttributesExStandard name =  alloca $ \res -> do
+  withTString name $ \ c_name ->
+    failIfFalseWithRetry_ "getFileAttributesExStandard" $
+      c_GetFileAttributesEx c_name getFileExInfoStandard res
+  peek res
 foreign import WINDOWS_CCONV unsafe "windows.h GetFileAttributesExW"
   c_GetFileAttributesEx :: LPCTSTR -> GET_FILEEX_INFO_LEVELS -> Ptr a -> IO BOOL
 


### PR DESCRIPTION
GetFileAttributesEx [1] has the peculiarity that it returns the information requested in a struct whose type depends on the value of the fInfoLevelId parameter. This causes a problem to haskell because we don't know what type to use. Because of that, I decided to split this pull request into two commits. The first one should be fairly uncontroversial: it introduces both datatypes required by GetFileAttributesEx and a c_\* function that directly calls GetFileAttributesEx. In the second commit, I introduce a function called getFileAttributesExStandard which calls GetFileAttributesEx with the fInfoLevelId parameter set to GetFileExInfoStandard. This is currently the only allowed value for this parameter. Because of the fact that there is a unique value for the paramater, I think this is a good compromise. I am open to any other suggestions.

Note that the absence of this function from Win32 blocks a bug with the directory package [2], which is a core package.

[1] http://msdn.microsoft.com/en-us/library/windows/desktop/aa364946%28v=vs.85%29.aspx
[2] http://hackage.haskell.org/trac/ghc/ticket/7473
