### PR TITLE
Use regCreateKey to be more robust when registry entry does not exist.

### DIFF
--- a/tests/registry001.hs
+++ b/tests/registry001.hs
@@ -7,9 +7,9 @@ name = "test_registry001"
 
 -- Create, read, and delete a value (test for bug #3241)
 main = do
-  k1 <- regOpenKey hKEY_CURRENT_USER "Software"
-  k2 <- regOpenKey k1 "Haskell"
-  k3 <- regOpenKey k2 "GHC"
+  k1 <- regCreateKey hKEY_CURRENT_USER "Software"
+  k2 <- regCreateKey k1 "Haskell"
+  k3 <- regCreateKey k2 "GHC"
   flip finally (regDeleteValue k3 name) $ do
   regSetStringValue k3 name x
   r <- regQueryValue k3 (Just name)


### PR DESCRIPTION
Signed-off-by: Edward Z. Yang ezyang@mit.edu
