### PR TITLE
Enable optional arguments in findWindow

### DIFF
--- a/Graphics/Win32/Window.hsc
+++ b/Graphics/Win32/Window.hsc
@@ -456,7 +456,7 @@ findWindow :: String -> String -> IO (Maybe HWND)
 findWindow cname wname =
   withTString cname $ \ c_cname ->
   withTString wname $ \ c_wname ->
-  liftM ptrToMaybe $ c_FindWindow c_cname c_wname
+  liftM ptrToMaybe $ c_FindWindow (if c_cname == "" then nullPtr else c_name) (if c_wname == "" then nullPtr else c_wname)
 foreign import WINDOWS_CCONV unsafe "windows.h FindWindowW"
   c_FindWindow :: LPCTSTR -> LPCTSTR -> IO HWND
 


### PR DESCRIPTION
Both arguments of `FindWindow` can be optional by setting them to `nullptr` (http://msdn.microsoft.com/en-us/library/windows/desktop/ms633499%28v=vs.85%29.aspx); A thing which is _not_ possible at the moment.
As passing an empty string is useless, empty strings are passed as `nullptr` instead.
Other ways to fix this are welcomed. :)
