### PR TITLE
Replace obsolete `defaultUserHooks` by `autoconfUserHooks`

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -3,4 +3,4 @@ module Main (main) where
 import Distribution.Simple
 
 main :: IO ()
-main = defaultMainWithHooks defaultUserHooks
+main = defaultMainWithHooks autoconfUserHooks


### PR DESCRIPTION
This is to avoid the warning printed otherwise when executing `Setup.hs`:

```
  Setup.hs:6:29: Warning:
      In the use of ‘defaultUserHooks’
      (imported from Distribution.Simple):
      Deprecated: "Use simpleUserHooks or autoconfUserHooks, unless you need Cabal-1.2
             compatibility in which case you must stick with defaultUserHooks"
  Warning: defaultUserHooks in Setup script is deprecated.
  Configuring Win32-2.3.0.2...
```
