### PR TITLE
Win32: Bump version of Win32 for usage in GHC 8.0.1

### DIFF
--- a/Win32.cabal
+++ b/Win32.cabal
@@ -1,5 +1,5 @@
 name:		Win32
-version:	2.3.1.0
+version:	2.3.1.1
 license:	BSD3
 license-file:	LICENSE
 author:		Alastair Reid


### PR DESCRIPTION
Bumped the version number of Win32 for the final release