### PR TITLE
Adds Long/Short path name conversion bindings

### DIFF
--- a/System/Win32/Info.hsc
+++ b/System/Win32/Info.hsc
@@ -125,6 +125,12 @@ getLongPathName name = do
     try "getLongPathName"
       (c_GetLongPathName c_name) 512
 
+getShortPathName :: FilePath -> IO FilePath
+getShortPathName name = do
+  withTString name $ \ c_name ->
+    try "getShortPathName"
+      (c_GetShortPathName c_name) 512
+
 searchPath :: Maybe String -> FilePath -> String -> IO (Maybe FilePath)
 searchPath path filename ext =
   maybe ($ nullPtr) withTString path $ \p_path ->
@@ -169,6 +175,9 @@ foreign import WINDOWS_CCONV unsafe "GetFullPathNameW"
 
 foreign import WINDOWS_CCONV unsafe "GetLongPathNameW"
   c_GetLongPathName :: LPCTSTR -> LPTSTR -> DWORD -> IO DWORD
+
+foreign import WINDOWS_CCONV unsafe "GetShortPathNameW"
+  c_GetShortPathName :: LPCTSTR -> LPTSTR -> DWORD -> IO DWORD
 
 foreign import WINDOWS_CCONV unsafe "SearchPathW"
   c_SearchPath :: LPCTSTR -> LPCTSTR -> LPCTSTR -> DWORD -> LPTSTR -> Ptr LPTSTR

--- a/System/Win32/Info.hsc
+++ b/System/Win32/Info.hsc
@@ -119,6 +119,12 @@ getFullPathName name = do
     try "getFullPathName"
       (\buf len -> c_GetFullPathName c_name len buf nullPtr) 512
 
+getLongPathName :: FilePath -> IO FilePath
+getLongPathName name = do
+  withTString name $ \ c_name ->
+    try "getLongPathName"
+      (c_GetLongPathName c_name) 512
+
 searchPath :: Maybe String -> FilePath -> String -> IO (Maybe FilePath)
 searchPath path filename ext =
   maybe ($ nullPtr) withTString path $ \p_path ->
@@ -160,6 +166,9 @@ foreign import WINDOWS_CCONV unsafe "GetTempPathW"
 
 foreign import WINDOWS_CCONV unsafe "GetFullPathNameW"
   c_GetFullPathName :: LPCTSTR -> DWORD -> LPTSTR -> Ptr LPTSTR -> IO DWORD
+
+foreign import WINDOWS_CCONV unsafe "GetLongPathNameW"
+  c_GetLongPathName :: LPCTSTR -> LPTSTR -> DWORD -> IO DWORD
 
 foreign import WINDOWS_CCONV unsafe "SearchPathW"
   c_SearchPath :: LPCTSTR -> LPCTSTR -> LPCTSTR -> DWORD -> LPTSTR -> Ptr LPTSTR

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 
 ## GIT HEAD (Unknown version)
 
+* Added function `getLongPathName`
+* Added function `getShortPathName`
 * Added function `getUserName`
 * Added file attribute `fILE_ATTRIBUTE_REPARSE_POINT`
 * Added more [`File Access Rights` constants](https://msdn.microsoft.com/en-us/library/windows/desktop/gg258116%28v=vs.85%29.aspx)


### PR DESCRIPTION
This adds bindings to the following path name functions:

* GetLongPathName - https://msdn.microsoft.com/en-us/library/windows/desktop/aa364980(v=vs.85).aspx
* GetShortPathName - https://msdn.microsoft.com/en-us/library/windows/desktop/aa364989(v=vs.85).aspx