### PR TITLE
Put windows_cconv.h in install-includes

### DIFF
--- a/Win32.cabal
+++ b/Win32.cabal
@@ -14,7 +14,7 @@ build-type:     Simple
 cabal-version:  >=1.6
 extra-source-files:
 	include/diatemp.h include/dumpBMP.h include/ellipse.h include/errors.h
-	include/Win32Aux.h include/win32debug.h include/windows_cconv.h
+	include/Win32Aux.h include/win32debug.h
 
 Library
     build-depends:	base >= 4.5 && < 5, bytestring
@@ -66,7 +66,7 @@ Library
         "user32", "gdi32", "winmm", "advapi32", "shell32", "shfolder"
     include-dirs: 	include
     includes:	"HsWin32.h", "HsGDI.h", "WndProc.h"
-    install-includes:	"HsWin32.h", "HsGDI.h", "WndProc.h"
+    install-includes:	"HsWin32.h", "HsGDI.h", "WndProc.h", "windows_cconv.h"
     c-sources:
         cbits/HsGDI.c
         cbits/HsWin32.c

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@
 
 ## GIT HEAD (Unknown version)
 
+* Add `windows_cconv.h` to the `install-includes` field of `Win32.cabal`,
+  allowing packages that transitively depend on `Win32` to use the
+  `WINDOWS_CCONV` CPP macro (which expands to `stdcall` or `ccall`
+  appropriately depending on the system architecture)
 * Added function `getLongPathName`
 * Added function `getShortPathName`
 * Added function `getUserName`


### PR DESCRIPTION
In just about every Windows project I have, I end up having to redefine the `WINDOWS_CCONV` macro myself in order to use it with Win32 API foreign imports. It would be handy if `Win32` simply reexported its own `WINDOWS_CCONV` macro by putting the file that defines in (`windows_cconv.h`) in the `install-includes` field of its `.cabal` file.