### PR TITLE
Call SetLastError before maperrno

### DIFF
--- a/System/Win32/Types.hs
+++ b/System/Win32/Types.hs
@@ -242,6 +242,7 @@ failWith fn_name err_code = do
                    -- We ignore failure of freeing c_msg, given we're already failing
                    _ <- localFree c_msg
                    return msg
+  setLastError err_code
   c_maperrno -- turn GetLastError() into errno, which errnoToIOError knows
              -- how to convert to an IOException we can throw.
              -- XXX we should really do this directly.
@@ -294,6 +295,9 @@ foreign import WINDOWS_CCONV unsafe "windows.h LocalFree"
 
 foreign import WINDOWS_CCONV unsafe "windows.h GetLastError"
   getLastError :: IO ErrCode
+
+foreign import WINDOWS_CCONV unsafe "windows.h SetLastError"
+  setLastError :: ErrCode -> IO ()
 
 {-# CFILES cbits/errors.c #-}
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased GIT version
 
+* `failWith` (and the API calls that use it) now throw `IOError`s with proper
+  `IOErrorType`s.
+
 ## 2.4.0.0 *Nov 2016*
 
 * Add `windows_cconv.h` to the `install-includes` field of `Win32.cabal`,


### PR DESCRIPTION
I've discovered that `failWith` doesn't work perfectly with `IOError`. In particular, it appears that it doesn't provide proper `IOErrorType`. GetLastError()-to-errno conversion aside, one issue seems to be that some WinAPI functions don't actually call `SetLastError`, returning an error code instead. In those cases, when `maperrno` is called, it converts a junk value returned by `GetLastError`. I added a call to `SetLastError` just before the call to `maperrno` so that it converts the actual error code returned by an API call.

I bumped into this while trying to detect when `regOpenKey` fails because of the key missing. I used `isDoesNotExistError` for this, only to discover that it doesn't work. I've created two repositories to demonstrate the issue and the fix:

* https://github.com/egor-tensin/win32-issue-bad
* https://github.com/egor-tensin/win32-issue-good

(The code is identical in both. I wanted to somehow make two source files instead of the full-fledges repos, but my cabal/stack-fu is not on par.)

I realize that this fix is lacking proper verification and testing; I'm just hoping somebody more competent will take a look.