### PR TITLE
Implement isMinTTY

### DIFF
--- a/System/Win32.hs
+++ b/System/Win32.hs
@@ -23,6 +23,7 @@ module System.Win32
         , module System.Win32.FileMapping
         , module System.Win32.Info
         , module System.Win32.Mem
+        , module System.Win32.MinTTY
         , module System.Win32.NLS
         , module System.Win32.Process
         , module System.Win32.Registry
@@ -38,6 +39,7 @@ import System.Win32.File
 import System.Win32.FileMapping
 import System.Win32.Info
 import System.Win32.Mem
+import System.Win32.MinTTY
 import System.Win32.NLS hiding  ( LCID, LANGID, SortID, SubLANGID
                                 , PrimaryLANGID, mAKELCID, lANGIDFROMLCID
                                 , sORTIDFROMLCID, mAKELANGID, pRIMARYLANGID

--- a/System/Win32/MinTTY.hsc
+++ b/System/Win32/MinTTY.hsc
@@ -165,7 +165,7 @@ instance Storable FILE_NAME_INFO where
             end   = advancePtr start len'
         (#poke FILE_NAME_INFO, FileNameLength) buf len'
         copyArray start (castPtr str :: Ptr Word8) len'
-        poke end 0
+        poke (castPtr end) (0 :: CWchar)
     peek buf = do
         vfniFileNameLength <- (#peek FILE_NAME_INFO, FileNameLength) buf
         let len = fromIntegral vfniFileNameLength `div` sizeOfWchar
@@ -208,7 +208,7 @@ instance Storable UNICODE_STRING where
         (#poke UNICODE_STRING, MaximumLength) buf (len' + sizeOfWchar)
         (#poke UNICODE_STRING, Buffer)        buf start
         copyArray start (castPtr str :: Ptr Word8) len'
-        poke end 0
+        poke (castPtr end) (0 :: CWchar)
     peek buf = do
         vusLength        <- (#peek UNICODE_STRING, Length)        buf
         vusMaximumLength <- (#peek UNICODE_STRING, MaximumLength) buf

--- a/System/Win32/MinTTY.hsc
+++ b/System/Win32/MinTTY.hsc
@@ -110,8 +110,8 @@ cygwinMSYSCheck fn = ("cygwin-" `isPrefixOf` fn' || "msys-" `isPrefixOf` fn') &&
 getFileNameByHandle :: HANDLE -> IO String
 getFileNameByHandle h = do
   let sizeOfDWORD = sizeOf (undefined :: DWORD)
-  -- note: implicitly assuming that DWORD has stronger alignment than wchar_t
-      bufSize = sizeOfDWORD + mAX_PATH * sizeOfTCHAR
+      -- note: implicitly assuming that DWORD has stronger alignment than wchar_t
+      bufSize     = sizeOfDWORD + mAX_PATH * sizeOfTCHAR
   allocaBytes bufSize $ \buf -> do
     getFileInformationByHandleEx h fileNameInfo buf (fromIntegral bufSize)
     fni <- peek buf
@@ -129,8 +129,8 @@ getFileInformationByHandleEx h cls buf bufSize = do
 
 ntQueryObjectNameInformation :: HANDLE -> IO String
 ntQueryObjectNameInformation h = do
-  let sizeOfONI    = sizeOf (undefined :: OBJECT_NAME_INFORMATION)
-      bufSize      = sizeOfONI + mAX_PATH * sizeOfTCHAR
+  let sizeOfONI = sizeOf (undefined :: OBJECT_NAME_INFORMATION)
+      bufSize   = sizeOfONI + mAX_PATH * sizeOfTCHAR
   allocaBytes bufSize $ \buf ->
     alloca $ \p_len -> do
       _ <- failIfNeg "NtQueryObject" $ c_NtQueryObject

--- a/System/Win32/MinTTY.hsc
+++ b/System/Win32/MinTTY.hsc
@@ -33,7 +33,7 @@ import Control.Exception (catch)
 #endif
 import Data.List (isInfixOf, isSuffixOf)
 import Data.Word (Word8)
-import Foreign hiding (void)
+import Foreign
 import Foreign.C.String
 import Foreign.C.Types
 

--- a/System/Win32/MinTTY.hsc
+++ b/System/Win32/MinTTY.hsc
@@ -49,7 +49,7 @@ import System.FilePath (takeFileName)
 #define _WIN32_WINNT 0x0600
 ##include "windows_cconv.h"
 #include <windows.h>
-#include <winternl.h>
+#include "winternl_compat.h"
 
 -- | Returns 'True' if the current process's standard error is attached to a
 -- MinTTY console (e.g., Cygwin or MSYS). Returns 'False' otherwise.

--- a/System/Win32/MinTTY.hsc
+++ b/System/Win32/MinTTY.hsc
@@ -43,6 +43,7 @@ import System.FilePath (takeFileName)
 -- The headers that are shipped with GHC's copy of MinGW-w64 assume Windows XP.
 -- Since we need some structs that are only available with Vista or later,
 -- we must manually set WINVER/_WIN32_WINNT accordingly.
+#undef WINVER
 #define WINVER 0x0600
 #undef _WIN32_WINNT
 #define _WIN32_WINNT 0x0600
@@ -56,9 +57,9 @@ isMinTTY :: IO Bool
 isMinTTY = do
     h <- getStdHandle sTD_ERROR_HANDLE
            `catch` \(_ :: IOError) ->
-             pure nullHANDLE
+             return nullHANDLE
     if h == nullHANDLE
-       then pure False
+       then return False
        else isMinTTYHandle h
 
 -- | Returns 'True' is the given handle is attached to a MinTTY console
@@ -67,7 +68,7 @@ isMinTTYHandle :: HANDLE -> IO Bool
 isMinTTYHandle h = do
     fileType <- getFileType h
     if fileType /= fILE_TYPE_PIPE
-      then pure False
+      then return False
       else isMinTTYVista h `catch` \(_ :: IOError) -> isMinTTYCompat h
       -- GetFileNameByHandleEx is only available on Vista and later (hence
       -- the name isMinTTYVista). If we're on an older version of Windows,
@@ -78,16 +79,16 @@ isMinTTYHandle h = do
 isMinTTYVista :: HANDLE -> IO Bool
 isMinTTYVista h = do
     fn <- getFileNameByHandle h
-    pure $ cygwinMSYSCheck fn
+    return $ cygwinMSYSCheck fn
   `catch` \(_ :: IOError) ->
-    pure False
+    return False
 
 isMinTTYCompat :: HANDLE -> IO Bool
 isMinTTYCompat h = do
     fn <- ntQueryObjectNameInformation h
-    pure $ cygwinMSYSCheck fn
+    return $ cygwinMSYSCheck fn
   `catch` \(_ :: IOError) ->
-    pure False
+    return False
 
 cygwinMSYSCheck :: String -> Bool
 cygwinMSYSCheck fn = ("cygwin-" `isPrefixOf` fn' || "msys-" `isPrefixOf` fn') &&

--- a/System/Win32/MinTTY.hsc
+++ b/System/Win32/MinTTY.hsc
@@ -111,7 +111,7 @@ getFileNameByHandle :: HANDLE -> IO String
 getFileNameByHandle h = do
   let sizeOfDWORD = sizeOf (undefined :: DWORD)
   -- note: implicitly assuming that DWORD has stronger alignment than wchar_t
-  let bufSize = sizeOfDWORD + mAX_PATH * sizeOfTCHAR
+      bufSize = sizeOfDWORD + mAX_PATH * sizeOfTCHAR
   allocaBytes bufSize $ \buf -> do
     getFileInformationByHandleEx h fileNameInfo buf (fromIntegral bufSize)
     fni <- peek buf
@@ -129,8 +129,8 @@ getFileInformationByHandleEx h cls buf bufSize = do
 
 ntQueryObjectNameInformation :: HANDLE -> IO String
 ntQueryObjectNameInformation h = do
-  let sizeOfUSHORT = sizeOf (undefined :: USHORT)
-  let bufSize = 8 * sizeOfUSHORT + mAX_PATH * sizeOfTCHAR
+  let sizeOfONI    = sizeOf (undefined :: OBJECT_NAME_INFORMATION)
+      bufSize      = sizeOfONI + mAX_PATH * sizeOfTCHAR
   allocaBytes bufSize $ \buf ->
     alloca $ \p_len -> do
       _ <- failIfNeg "NtQueryObject" $ c_NtQueryObject

--- a/System/Win32/MinTTY.hsc
+++ b/System/Win32/MinTTY.hsc
@@ -1,0 +1,207 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+#if __GLASGOW_HASKELL__ >= 709
+{-# LANGUAGE Safe #-}
+#elif __GLASGOW_HASKELL__ >= 701
+{-# LANGUAGE Trustworthy #-}
+#endif
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  System.Win32.MinTTY
+-- Copyright   :  (c) University of Glasgow 2006
+-- License     :  BSD-style (see the file LICENSE)
+--
+-- Maintainer  :  Esa Ilari Vuokko <ei@vuokko.info>
+-- Stability   :  provisional
+-- Portability :  portable
+--
+-- A function to check if the current terminal uses MinTTY.
+-- Much of this code was originally authored by Phil Ruffwind.
+--
+-----------------------------------------------------------------------------
+
+module System.Win32.MinTTY (isMinTTY) where
+
+import Graphics.Win32.Misc
+import System.Win32.DLL
+import System.Win32.File
+import System.Win32.Types
+
+#if MIN_VERSION_base(4,6,0)
+import Control.Exception (catch)
+#endif
+import Control.Monad (void)
+import Data.List (isInfixOf, isSuffixOf)
+import Foreign hiding (void)
+import Foreign.C.String
+import Foreign.C.Types
+
+#if __GLASGOW_HASKELL__ < 711
+#let alignment t = "%lu", (unsigned long)offsetof(struct {char x__; t (y__); }, y__)
+#endif
+
+##include "windows_cconv.h"
+#include <windows.h>
+
+-- | Returns 'True' is running on a MinTTY console (e.g., Cygwin or MSYS).
+-- Returns 'False' otherwise.
+isMinTTY :: IO Bool
+isMinTTY = do
+    h <- getStdHandle sTD_ERROR_HANDLE
+    fileType <- getFileType h
+    if fileType /= fILE_TYPE_PIPE
+      then pure False
+      else do
+        -- GetFileNameByHandleEx is only available on Vista and later, so if
+        -- we're on an older version of Windows, we must default to using
+        -- NtQueryObject.
+        vistaPlus <- isVistaOrLater
+        if vistaPlus
+           then isMinTTYVista h
+           else isMinTTYCompat h
+
+isMinTTYVista :: HANDLE -> IO Bool
+isMinTTYVista h = do
+    fn <- getFileNameByHandle h
+    pure $ cygwinMSYSCheck fn
+  `catch` \ (_ :: IOError) ->
+    pure False
+
+isMinTTYCompat :: HANDLE -> IO Bool
+isMinTTYCompat h = do
+    fn <- ntQueryObjectNameInformation h
+    pure $ cygwinMSYSCheck fn
+  `catch` \ (_ :: IOError) ->
+    pure False
+
+cygwinMSYSCheck :: String -> Bool
+cygwinMSYSCheck fn = ("\\cygwin-" `isInfixOf` fn || "\\msys-" `isInfixOf` fn) &&
+            "-pty" `isInfixOf` fn &&
+            "-master" `isSuffixOf` fn
+-- Note that GetFileInformationByHandleEx might return something like:
+--
+--    \msys-dd50a72ab4668b33-pty1-to-master
+--
+-- But NtQueryObject might return something like:
+--
+--    \Device\NamedPipe\msys-dd50a72ab4668b33-pty1-to-master
+--
+-- This means we can't rely on "cygwin-" or "msys-" being at the very start,
+-- so we check for their presence using `isInfixOf` instead of `isPrefixOf`.
+
+getFileNameByHandle :: HANDLE -> IO String
+getFileNameByHandle h = do
+  let sizeOfDWORD = sizeOf (undefined :: DWORD)
+  let sizeOfWchar = sizeOf (undefined :: CWchar)
+  -- note: implicitly assuming that DWORD has stronger alignment than wchar_t
+  let bufSize = sizeOfDWORD + mAX_PATH * sizeOfWchar
+  allocaBytes bufSize $ \buf -> do
+    getFileInformationByHandleEx h fILE_NAME_INFO buf (fromIntegral bufSize)
+    len :: DWORD <- peek buf
+    let len' = fromIntegral len `div` sizeOfWchar
+    peekCWStringLen (buf `plusPtr` sizeOfDWORD, min len' mAX_PATH)
+
+getFileInformationByHandleEx
+  :: HANDLE -> CInt -> Ptr a -> DWORD -> IO ()
+getFileInformationByHandleEx h cls buf bufSize = do
+  lib <- getModuleHandle (Just "kernel32.dll")
+  ptr <- getProcAddress lib "GetFileInformationByHandleEx"
+  let c_GetFileInformationByHandleEx =
+        mk_GetFileInformationByHandleEx (castPtrToFunPtr ptr)
+  failIfFalse_ "getFileInformationByHandleEx"
+    (c_GetFileInformationByHandleEx h cls buf bufSize)
+
+ntQueryObjectNameInformation :: HANDLE -> IO String
+ntQueryObjectNameInformation h = do
+  let sizeOfUSHORT = sizeOf (undefined :: USHORT)
+  let sizeOfWchar  = sizeOf (undefined :: CWchar)
+  let bufSize = 8 * sizeOfUSHORT + mAX_PATH * sizeOfWchar
+  allocaBytes bufSize $ \buf ->
+    alloca $ \p_len -> do
+      ntQueryObject h oBJECT_NAME_INFORMATION buf (fromIntegral bufSize) p_len
+      len :: USHORT <- peek buf
+      let len' = fromIntegral len `div` sizeOfWchar
+      peekCWStringLen (buf `plusPtr` (8 * sizeOfUSHORT), min len' mAX_PATH)
+
+ntQueryObject :: HANDLE -> CInt -> Ptr a -> ULONG -> Ptr ULONG -> IO ()
+ntQueryObject h cls buf bufSize p_len = do
+  lib <- getModuleHandle (Just "ntdll.dll")
+  ptr <- getProcAddress lib "NtQueryObject"
+  let c_NtQueryObject = mk_NtQueryObject (castPtrToFunPtr ptr)
+  void $ failIfNeg "NtQueryObject" $ c_NtQueryObject h cls buf bufSize p_len
+
+isVistaOrLater :: IO Bool
+isVistaOrLater = do
+  lib <- getModuleHandle (Just "ntdll.dll")
+  ptr <- getProcAddress lib "RtlGetVersion"
+  let c_RtlGetVersion = mk_RtlGetVersion (castPtrToFunPtr ptr)
+  osVersionInfo <- alloca $ \p -> do
+    _ <- failIfNeg "RtlGetVersion" $ c_RtlGetVersion p
+    peek p
+  return $ dwMajorVersion osVersionInfo >= 6
+
+fILE_NAME_INFO :: CInt
+fILE_NAME_INFO = 2
+
+mAX_PATH :: Num a => a
+mAX_PATH = #const MAX_PATH
+
+oBJECT_NAME_INFORMATION :: CInt
+oBJECT_NAME_INFORMATION = 1
+
+type F_GetFileInformationByHandleEx a =
+  HANDLE -> CInt -> Ptr a -> DWORD -> IO BOOL
+
+foreign import WINDOWS_CCONV "dynamic"
+  mk_GetFileInformationByHandleEx
+  :: FunPtr (F_GetFileInformationByHandleEx a)
+  -> F_GetFileInformationByHandleEx a
+
+type F_NtQueryObject a =
+  HANDLE -> CInt -> Ptr a -> ULONG -> Ptr ULONG -> IO NTSTATUS
+
+foreign import WINDOWS_CCONV "dynamic"
+  mk_NtQueryObject :: FunPtr (F_NtQueryObject a) -> F_NtQueryObject a
+
+type F_RtlGetVersion = Ptr RTL_OSVERSIONINFOW -> IO NTSTATUS
+
+foreign import WINDOWS_CCONV "dynamic"
+  mk_RtlGetVersion :: FunPtr F_RtlGetVersion -> F_RtlGetVersion
+
+type ULONG    = #type ULONG
+type NTSTATUS = #type NTSTATUS
+
+data RTL_OSVERSIONINFOW = RTL_OSVERSIONINFOW
+  { dwOSVersionInfoSize :: ULONG
+  , dwMajorVersion      :: ULONG
+  , dwMinorVersion      :: ULONG
+  , dwBuildNumber       :: ULONG
+  , dwPlatformId        :: ULONG
+  , szCSDVersion        :: CWString
+  } deriving Show
+
+instance Storable RTL_OSVERSIONINFOW where
+  sizeOf    _ = #size      RTL_OSVERSIONINFOW
+  alignment _ = #alignment RTL_OSVERSIONINFOW
+  poke buf ovi = do
+      (#poke RTL_OSVERSIONINFOW, dwOSVersionInfoSize) buf (dwOSVersionInfoSize ovi)
+      (#poke RTL_OSVERSIONINFOW, dwMajorVersion)      buf (dwMajorVersion      ovi)
+      (#poke RTL_OSVERSIONINFOW, dwMinorVersion)      buf (dwMinorVersion      ovi)
+      (#poke RTL_OSVERSIONINFOW, dwBuildNumber)       buf (dwBuildNumber       ovi)
+      (#poke RTL_OSVERSIONINFOW, dwPlatformId)        buf (dwPlatformId        ovi)
+      (#poke RTL_OSVERSIONINFOW, szCSDVersion)        buf (dwPlatformId        ovi)
+  peek buf = do
+      osVersionInfoSize <- (#peek RTL_OSVERSIONINFOW, dwOSVersionInfoSize) buf
+      majorVersion      <- (#peek RTL_OSVERSIONINFOW, dwMajorVersion)      buf
+      minorVersion      <- (#peek RTL_OSVERSIONINFOW, dwMinorVersion)      buf
+      buildNumber       <- (#peek RTL_OSVERSIONINFOW, dwBuildNumber)       buf
+      platformId        <- (#peek RTL_OSVERSIONINFOW, dwPlatformId)        buf
+      csdVersion        <- (#peek RTL_OSVERSIONINFOW, szCSDVersion)        buf
+      return $ RTL_OSVERSIONINFOW
+        { dwOSVersionInfoSize = osVersionInfoSize
+        , dwMajorVersion      = majorVersion
+        , dwMinorVersion      = minorVersion
+        , dwBuildNumber       = buildNumber
+        , dwPlatformId        = platformId
+        , szCSDVersion        = csdVersion
+        }

--- a/System/Win32/Types.hs
+++ b/System/Win32/Types.hs
@@ -207,6 +207,9 @@ failIf_ p wh act = do
   v <- act
   if p v then errorWin wh else return ()
 
+failIfNeg :: (Num a, Ord a) => String -> IO a -> IO a
+failIfNeg = failIf (< 0)
+
 failIfNull :: String -> IO (Ptr a) -> IO (Ptr a)
 failIfNull = failIf (== nullPtr)
 
@@ -279,7 +282,7 @@ try loc f n = do
    case e of
         Left n    -> try loc f n
         Right str -> return str
-  
+
 ----------------------------------------------------------------
 -- Primitives
 ----------------------------------------------------------------

--- a/System/Win32/Types.hs
+++ b/System/Win32/Types.hs
@@ -71,6 +71,7 @@ type DWORD         = Word32
 type LONG          = Int32
 type FLOAT         = Float
 type LARGE_INTEGER = Int64
+type ULONG         = Word32
 
 type UINT_PTR      = Word
 type LONG_PTR      = CIntPtr

--- a/Win32.cabal
+++ b/Win32.cabal
@@ -66,7 +66,7 @@ Library
     if impl(ghc >= 7.1)
         extensions: NondecreasingIndentation
     extra-libraries:
-        "user32", "gdi32", "winmm", "advapi32", "shell32", "shfolder", "shlwapi"
+        "user32", "gdi32", "winmm", "advapi32", "shell32", "shfolder", "shlwapi", "ntdll"
     include-dirs: 	include
     includes:	"HsWin32.h", "HsGDI.h", "WndProc.h"
     install-includes:	"HsWin32.h", "HsGDI.h", "WndProc.h", "windows_cconv.h"

--- a/Win32.cabal
+++ b/Win32.cabal
@@ -18,7 +18,7 @@ extra-source-files:
         changelog.md
 
 Library
-    build-depends:	base >= 4.5 && < 5, bytestring
+    build-depends:	base >= 4.5 && < 5, bytestring, filepath
     ghc-options:    -Wall -fno-warn-name-shadowing
     cc-options:     -fno-strict-aliasing
     exposed-modules:

--- a/Win32.cabal
+++ b/Win32.cabal
@@ -69,7 +69,7 @@ Library
         "user32", "gdi32", "winmm", "advapi32", "shell32", "shfolder", "shlwapi", "ntdll"
     include-dirs: 	include
     includes:	"HsWin32.h", "HsGDI.h", "WndProc.h"
-    install-includes:	"HsWin32.h", "HsGDI.h", "WndProc.h", "windows_cconv.h"
+    install-includes:	"HsWin32.h", "HsGDI.h", "WndProc.h", "windows_cconv.h", "winternl_compat.h"
     c-sources:
         cbits/HsGDI.c
         cbits/HsWin32.c

--- a/Win32.cabal
+++ b/Win32.cabal
@@ -52,6 +52,7 @@ Library
         System.Win32.Info
         System.Win32.Path
         System.Win32.Mem
+        System.Win32.MinTTY
         System.Win32.NLS
         System.Win32.Process
         System.Win32.Registry

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * `failWith` (and the API calls that use it) now throw `IOError`s with proper
   `IOErrorType`s.
 * Add `System.Win32.MinTTY` module for detecting the presence of MinTTY.
+* Add `ULONG` type to `System.Win32.Types`.
 * Add function `failIfNeg` to `System.Win32.Types`, which fails if a negative
   number is returned. This simulates the behavior of the `NT_SUCCESS` macro.
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@
 
 * `failWith` (and the API calls that use it) now throw `IOError`s with proper
   `IOErrorType`s.
+* Add `System.Win32.MinTTY` module for detecting the presence of MinTTY.
+* Add function `failIfNeg` to `System.Win32.Types`, which fails if a negative
+  number is returned. This simulates the behavior of the `NT_SUCCESS` macro.
 
 ## 2.4.0.0 *Nov 2016*
 

--- a/include/winternl_compat.h
+++ b/include/winternl_compat.h
@@ -1,0 +1,39 @@
+#ifndef WINTERNL_COMPAT_H
+#define WINTERNL_COMPAT_H
+
+/*
+ * winternl.h is not included in MinGW, which was shipped with the 32-bit
+ * Windows version of GHC prior to the 7.10.3 release.
+ */
+#if defined(x86_64_HOST_ARCH) || \
+   __GLASGOW_HASKELL__ >= 711 || \
+   (__GLASGOW_HASKELL__ == 710 && \
+    defined(__GLASGOW_HASKELL_PATCHLEVEL1__) && \
+    __GLASGOW_HASKELL_PATCHLEVEL1__ >= 2)
+# include <winternl.h>
+#else
+// Some declarations from winternl.h that we need in Win32
+# include <windows.h>
+
+typedef enum _OBJECT_INFORMATION_CLASS {
+   ObjectBasicInformation,
+   ObjectNameInformation,
+   ObjectTypeInformation,
+   ObjectAllInformation,
+   ObjectDataInformation
+} OBJECT_INFORMATION_CLASS, *POBJECT_INFORMATION_CLASS;
+
+typedef LONG NTSTATUS, *PNTSTATUS;
+
+typedef struct _UNICODE_STRING {
+  USHORT Length;
+  USHORT MaximumLength;
+  PWSTR  Buffer;
+} UNICODE_STRING, *PUNICODE_STRING;
+
+typedef struct _OBJECT_NAME_INFORMATION {
+  UNICODE_STRING Name;
+} OBJECT_NAME_INFORMATION, *POBJECT_NAME_INFORMATION;
+#endif
+
+#endif /* WINTERNL_COMPAT_H */


### PR DESCRIPTION
Fixes #62. This adapts code written [here](https://phabricator.haskell.org/D2809) (by Phil Ruffwind) and [here](https://github.com/git-for-windows/git/blob/4af28e2fb4af1069c81a3dcfab0332498e8424de/compat/winansi.c#L624-L649) (from `git-for-windows`) to provide a backwards-compatible way to tell if you're running in a MinTTY console on Windows.

I have some concerns that I'll leave as inline comments.