### PR TITLE
Fix poke implementation for TIME_ZONE_INFORMATION

### DIFF
--- a/System/Win32/Time.hsc
+++ b/System/Win32/Time.hsc
@@ -111,10 +111,11 @@ instance Storable TIME_ZONE_INFORMATION where
         where
             write buf offset str = withCWStringLen str $ \(str,len) -> do
                 when (len>31) $ fail "Storable TIME_ZONE_INFORMATION.poke: Too long string."
-                let start = (advancePtr (castPtr buf) offset)
-                    end = advancePtr start len
-                copyArray (castPtr str :: Ptr Word8) start len
-                poke end 0
+                let len'  = len * sizeOf (undefined :: CWchar)
+                    start = (advancePtr (castPtr buf) offset)
+                    end   = advancePtr start len'
+                copyArray start (castPtr str :: Ptr Word8) len'
+                poke (castPtr end) (0 :: CWchar)
     peek buf = do
         bias <- (#peek TIME_ZONE_INFORMATION, Bias)         buf
         sdat <- (#peek TIME_ZONE_INFORMATION, StandardDate) buf

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 * `failWith` (and the API calls that use it) now throw `IOError`s with proper
   `IOErrorType`s.
+* Fix a bug in the implementation of `poke` for `TIME_ZONE_INFORMATION` which
+  would cause it to be marshalled incorrectly.
 
 ## 2.4.0.0 *Nov 2016*
 

--- a/tests/PokeTZI.hs
+++ b/tests/PokeTZI.hs
@@ -1,0 +1,15 @@
+module Main where
+
+import Control.Exception (assert)
+import Foreign
+import System.Win32.Time
+
+main :: IO ()
+main = do
+    (_, tzi) <- getTimeZoneInformation
+    alloca $ \buf -> do
+        poke buf tzi
+        tzi' <- peek buf
+        print tzi
+        print tzi'
+        assert (tzi == tzi') $ return ()

--- a/tests/all.T
+++ b/tests/all.T
@@ -6,3 +6,4 @@ test('helloworld', skip, compile_and_run, ['-package lang -package win32'])
 
 test('lasterror', normal, compile_and_run, ['-package Win32'])
 test('T4452', normal, compile_and_run, ['-package Win32'])
+test('PokeTZI', normal, compile_and_run, ['-package Win32'])


### PR DESCRIPTION
It turns out the implementation of `poke` for `TIME_ZONE_INFORMATION` is incorrect for a number of reasons:

1. Foremost, the order of arguments to `copyArray` is completely wrong. The first array is the destination and the second is the source, so we need to flip the order in which the arguments currently appear.
2. We weren't copying enough bytes in the first place, as `withCWStringLen` gives you the length of the string, not the number of bytes. Luckily, this is easily fixed by multiplying `len` by `sizeOf (undefined :: CWchar`).
3. We need to ensure that we null-terminate the `CWstring` with an actual `CWchar`, not a `Word8`. I've observed that doing the latter can sometimes yield garbage strings.

Fixes #64.