### PR TITLE
Add function to find window by name only

### DIFF
--- a/Graphics/Win32/Window.hsc
+++ b/Graphics/Win32/Window.hsc
@@ -475,6 +475,11 @@ findWindow cname wname =
   withTString cname $ \ c_cname ->
   withTString wname $ \ c_wname ->
   liftM ptrToMaybe $ c_FindWindow c_cname c_wname
+
+findWindowByName :: String -> IO (Maybe HWND)
+findWindowByName wname = withTString wname $ \ c_wname ->
+  liftM ptrToMaybe $ c_FindWindow nullPtr c_wname
+
 foreign import WINDOWS_CCONV unsafe "windows.h FindWindowW"
   c_FindWindow :: LPCTSTR -> LPCTSTR -> IO HWND
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 * `failWith` (and the API calls that use it) now throw `IOError`s with proper
   `IOErrorType`s.
+* Add function `findWindowByName`
 
 ## 2.4.0.0 *Nov 2016*
 


### PR DESCRIPTION
Add function to find window by name only.  There already exists a helper function `findWindow`, but because its input parameters are `String`'s, it is impossible to find a window by name alone as `nullPtr` cannot be passed for the class name parameter

The win32 function, `FindWindow`, only considers the window name parameter if the class name parameter is null: https://msdn.microsoft.com/en-us/library/windows/desktop/ms633499(v=vs.85).aspx