### PR TITLE
Respect signedness of literals

### DIFF
--- a/Graphics/Win32/Menu.hsc
+++ b/Graphics/Win32/Menu.hsc
@@ -79,7 +79,7 @@ type MenuName = LPCTSTR
 
 checkMenuItem :: HMENU -> MenuItem -> MenuFlag -> IO Bool
 checkMenuItem menu item check = do
-  rv <- failIf (== -1) "CheckMenuItem" $ c_CheckMenuItem menu item check
+  rv <- failIf (== maxBound) "CheckMenuItem" $ c_CheckMenuItem menu item check
   return (rv == mF_CHECKED)
 foreign import WINDOWS_CCONV unsafe "windows.h CheckMenuItem"
   c_CheckMenuItem :: HMENU -> UINT -> UINT -> IO DWORD
@@ -230,13 +230,13 @@ foreign import WINDOWS_CCONV unsafe "windows.h GetMenu"
 
 getMenuDefaultItem :: HMENU -> Bool -> GMDIFlag -> IO MenuItem
 getMenuDefaultItem menu bypos flags =
-  failIf (== -1) "GetMenuDefaultItem" $ c_GetMenuDefaultItem menu bypos flags
+  failIf (== maxBound) "GetMenuDefaultItem" $ c_GetMenuDefaultItem menu bypos flags
 foreign import WINDOWS_CCONV unsafe "windows.h GetMenuDefaultItem"
   c_GetMenuDefaultItem :: HMENU -> Bool -> UINT -> IO UINT
 
 getMenuState :: HMENU -> MenuItem -> MenuFlag -> IO MenuState
 getMenuState menu item flags =
-  failIf (== -1) "GetMenuState" $ c_GetMenuState menu item flags
+  failIf (== maxBound) "GetMenuState" $ c_GetMenuState menu item flags
 foreign import WINDOWS_CCONV unsafe "windows.h GetMenuState"
   c_GetMenuState :: HMENU -> UINT -> UINT -> IO MenuState
 
@@ -254,7 +254,7 @@ foreign import WINDOWS_CCONV unsafe "windows.h SetMenu"
 
 getMenuItemCount :: HMENU -> IO Int
 getMenuItemCount menu =
-  failIf (== -1) "GetMenuItemCount" $ c_GetMenuItemCount menu
+  failIf (== maxBound) "GetMenuItemCount" $ c_GetMenuItemCount menu
 foreign import WINDOWS_CCONV unsafe "windows.h GetMenuItemCount"
   c_GetMenuItemCount :: HMENU -> IO Int
 
@@ -262,7 +262,7 @@ type MenuID = UINT
 
 getMenuItemID :: HMENU -> MenuItem -> IO MenuID
 getMenuItemID menu item =
-  failIf (== -1) "GetMenuItemID" $ c_GetMenuItemID menu item
+  failIf (== maxBound) "GetMenuItemID" $ c_GetMenuItemID menu item
 foreign import WINDOWS_CCONV unsafe "windows.h GetMenuItemID"
   c_GetMenuItemID :: HMENU -> UINT -> IO MenuID
 

--- a/Graphics/Win32/Window.hsc
+++ b/Graphics/Win32/Window.hsc
@@ -20,7 +20,7 @@ module Graphics.Win32.Window where
 
 import Control.Monad (liftM)
 import Data.Maybe (fromMaybe)
-import Data.Word (Word32)
+import Data.Int (Int32)
 import Foreign.ForeignPtr (withForeignPtr)
 import Foreign.Marshal.Alloc (allocaBytes)
 import Foreign.Ptr (FunPtr, Ptr, castFunPtrToPtr, castPtr, nullPtr)
@@ -185,7 +185,7 @@ type WindowStyleEx   = DWORD
 
 cW_USEDEFAULT :: Pos
 -- See Note [Overflow checking and fromIntegral] in Graphics/Win32/GDI/HDC.hs
-cW_USEDEFAULT = fromIntegral (#{const CW_USEDEFAULT} :: Word32)
+cW_USEDEFAULT = fromIntegral (#{const CW_USEDEFAULT} :: Int32)
 
 type Pos = Int
 

--- a/System/Win32/Types.hsc
+++ b/System/Win32/Types.hsc
@@ -219,7 +219,7 @@ nullFinalHANDLE :: ForeignPtr a
 nullFinalHANDLE = unsafePerformIO (newForeignPtr_ nullPtr)
 
 iNVALID_HANDLE_VALUE :: HANDLE
-iNVALID_HANDLE_VALUE = castUINTPtrToPtr (-1)
+iNVALID_HANDLE_VALUE = castUINTPtrToPtr maxBound
 
 foreign import ccall "_open_osfhandle"
   _open_osfhandle :: CIntPtr -> CInt -> IO CInt


### PR DESCRIPTION
Various places in the library signed literals were used at unsigned types. Here we replace these with their appropriate unsigned equivalents.