### PR TITLE
Drop ntdll dependency

### DIFF
--- a/Win32.cabal
+++ b/Win32.cabal
@@ -1,5 +1,5 @@
 name:		Win32
-version:	2.5.2.0
+version:	2.5.3.0
 license:	BSD3
 license-file:	LICENSE
 author:		Alastair Reid, shelarcy

--- a/Win32.cabal
+++ b/Win32.cabal
@@ -94,7 +94,7 @@ Library
     if impl(ghc >= 7.1)
         extensions: NondecreasingIndentation
     extra-libraries:
-        "user32", "gdi32", "winmm", "advapi32", "shell32", "shfolder", "shlwapi", "msimg32", "imm32", "ntdll"
+        "user32", "gdi32", "winmm", "advapi32", "shell32", "shfolder", "shlwapi", "msimg32", "imm32"
     ghc-options:      -Wall
     include-dirs:     include
     includes:         "alphablend.h", "diatemp.h", "dumpBMP.h", "ellipse.h", "errors.h", "HsGDI.h", "HsWin32.h", "Win32Aux.h", "win32debug.h", "windows_cconv.h", "WndProc.h", "alignment.h"

--- a/changelog.md
+++ b/changelog.md
@@ -1,15 +1,15 @@
 # Changelog for [`Win32` package](http://hackage.haskell.org/package/Win32)
 
-## Unreleased GIT Version
+## 2.5.3.0 *March 2017*
 
 * Fix buffer overflow in `regSetValue`. (See #39)
 * Added `getPixel`. (See #37)
+* Drop dependency on `ntdll` because of incorrect import library on x86. (See #79)
 
 ## 2.5.2.0 *March 2017*
 
 * Fix constant underflows with (-1) and unsigned numbers.
 * Add `commandLineToArgv`
-* Drop dependency on `ntdll` because of incorrect import library on x86. (See #79)
 
 ## 2.5.1.0 *Feb 2017*
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,7 @@
 
 * Fix constant underflows with (-1) and unsigned numbers.
 * Add `commandLineToArgv`
-* Drop dependency on `ntdll`
+* Drop dependency on `ntdll` because of incorrect import library on x86. (See #79)
 
 ## 2.5.1.0 *Feb 2017*
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 
 * Fix constant underflows with (-1) and unsigned numbers.
 * Add `commandLineToArgv`
+* Drop dependency on `ntdll`
 
 ## 2.5.1.0 *Feb 2017*
 


### PR DESCRIPTION
The dependency on `ntdll` is causing trouble on `x86`.  Dynamically load it instead.

https://sourceforge.net/p/mingw-w64/bugs/596/
https://ghc.haskell.org/trac/ghc/ticket/13431