### PR TITLE
Encode platform requirement in cabal meta-data

### DIFF
--- a/Win32.cabal
+++ b/Win32.cabal
@@ -18,6 +18,11 @@ extra-source-files:
         changelog.md
 
 Library
+    if !os(windows)
+        -- This package requires Windows to build
+        build-depends: unbuildable<0
+        buildable: False
+
     build-depends:	base >= 4.5 && < 5, bytestring, filepath
     ghc-options:    -Wall -fno-warn-name-shadowing
     cc-options:     -fno-strict-aliasing


### PR DESCRIPTION
This mirrors a similar provision made in recent `unix` package versions which contain
the dual `if !os(windows)`-unbuildable construct.