### PR TITLE
Nullable pointers now wrapped in Maybe

### DIFF
--- a/Graphics/Win32/Menu.hsc
+++ b/Graphics/Win32/Menu.hsc
@@ -446,23 +446,23 @@ foreign import WINDOWS_CCONV unsafe "windows.h TrackPopupMenuEx"
 -- Note: these 3 assume the flags don't include MF_BITMAP or MF_OWNERDRAW
 -- (which are hidden by this interface)
 
-appendMenu :: HMENU -> MenuFlag -> MenuID -> String -> IO ()
+appendMenu :: HMENU -> MenuFlag -> MenuID -> Maybe String -> IO ()
 appendMenu menu flags id_item name =
-  withTString name $ \ c_name ->
+  maybeWith withTString name $ \ c_name ->
   failIfFalse_ "AppendMenu" $ c_AppendMenu menu flags id_item c_name
 foreign import WINDOWS_CCONV unsafe "windows.h AppendMenuW"
   c_AppendMenu :: HMENU -> UINT -> MenuID -> LPCTSTR -> IO Bool
 
-insertMenu :: HMENU -> MenuItem -> MenuFlag -> MenuID -> String -> IO ()
+insertMenu :: HMENU -> MenuItem -> MenuFlag -> MenuID -> Maybe String -> IO ()
 insertMenu menu item flags id_item name =
-  withTString name $ \ c_name ->
+  maybeWith withTString name $ \ c_name ->
   failIfFalse_ "InsertMenu" $ c_InsertMenu menu item flags id_item c_name
 foreign import WINDOWS_CCONV unsafe "windows.h InsertMenuW"
   c_InsertMenu :: HMENU -> UINT -> UINT -> MenuID -> LPCTSTR -> IO Bool
 
-modifyMenu :: HMENU -> MenuItem -> MenuFlag -> MenuID -> String -> IO ()
+modifyMenu :: HMENU -> MenuItem -> MenuFlag -> MenuID -> Maybe String -> IO ()
 modifyMenu menu item flags id_item name =
-  withTString name $ \ c_name ->
+  maybeWith withTString name $ \ c_name ->
   failIfFalse_ "ModifyMenu" $ c_ModifyMenu menu item flags id_item c_name
 foreign import WINDOWS_CCONV unsafe "windows.h ModifyMenuW"
   c_ModifyMenu :: HMENU -> UINT -> UINT -> MenuID -> LPCTSTR -> IO Bool

--- a/Graphics/Win32/Misc.hsc
+++ b/Graphics/Win32/Misc.hsc
@@ -128,11 +128,11 @@ type MBStatus = UINT
 
 -- Note: if the error is ever raised, we're in a very sad way!
 
-messageBox :: HWND -> String -> String -> MBStyle -> IO MBStatus
+messageBox :: Maybe HWND -> String -> String -> MBStyle -> IO MBStatus
 messageBox wnd text caption style =
   withTString text $ \ c_text ->
   withTString caption $ \ c_caption ->
-  failIfZero "MessageBox" $ c_MessageBox wnd c_text c_caption style
+  failIfZero "MessageBox" $ c_MessageBox (maybePtr wnd) c_text c_caption style
 foreign import WINDOWS_CCONV safe "windows.h MessageBoxW"
   c_MessageBox :: HWND -> LPCTSTR -> LPCTSTR -> MBStyle -> IO MBStatus
 

--- a/System/Win32/DLL.hsc
+++ b/System/Win32/DLL.hsc
@@ -23,6 +23,7 @@ import System.Win32.Types
 
 import Foreign
 import Foreign.C
+import Data.Maybe (fromMaybe)
 
 ##include "windows_cconv.h"
 
@@ -87,10 +88,10 @@ loadLibraryEx name h flags =
 foreign import WINDOWS_CCONV unsafe "windows.h LoadLibraryExW"
   c_LoadLibraryEx :: LPCTSTR -> HANDLE -> LoadLibraryFlags -> IO HINSTANCE
 
-setDllDirectory :: String -> IO ()
+setDllDirectory :: Maybe String -> IO ()
 setDllDirectory name =
-  withTString name $ \ c_name ->
-  failIfFalse_ (unwords ["SetDllDirectory", name]) $ c_SetDllDirectory c_name
+  maybeWith withTString name $ \ c_name ->
+  failIfFalse_ (unwords ["SetDllDirectory", fromMaybe "NULL" name]) $ c_SetDllDirectory c_name
 
 foreign import WINDOWS_CCONV unsafe "windows.h SetDllDirectoryW"
   c_SetDllDirectory :: LPTSTR -> IO BOOL

--- a/System/Win32/File.hsc
+++ b/System/Win32/File.hsc
@@ -376,10 +376,10 @@ moveFile src dest =
 foreign import WINDOWS_CCONV unsafe "windows.h MoveFileW"
   c_MoveFile :: LPCTSTR -> LPCTSTR -> IO Bool
 
-moveFileEx :: String -> String -> MoveFileFlag -> IO ()
+moveFileEx :: String -> Maybe String -> MoveFileFlag -> IO ()
 moveFileEx src dest flags =
   withTString src $ \ c_src ->
-  withTString dest $ \ c_dest ->
+  maybeWith withTString dest $ \ c_dest ->
   failIfFalseWithRetry_ (unwords ["MoveFileEx",show src,show dest]) $
     c_MoveFileEx c_src c_dest flags
 foreign import WINDOWS_CCONV unsafe "windows.h MoveFileExW"
@@ -609,9 +609,9 @@ foreign import WINDOWS_CCONV unsafe "windows.h FindClose"
 -- DOS Device flags
 ----------------------------------------------------------------
 
-defineDosDevice :: DefineDosDeviceFlags -> String -> String -> IO ()
+defineDosDevice :: DefineDosDeviceFlags -> String -> Maybe String -> IO ()
 defineDosDevice flags name path =
-  withTString path $ \ c_path ->
+  maybeWith withTString path $ \ c_path ->
   withTString name $ \ c_name ->
   failIfFalse_ "DefineDosDevice" $ c_DefineDosDevice flags c_name c_path
 foreign import WINDOWS_CCONV unsafe "windows.h DefineDosDeviceW"
@@ -661,10 +661,10 @@ getDiskFreeSpace path =
 foreign import WINDOWS_CCONV unsafe "windows.h GetDiskFreeSpaceW"
   c_GetDiskFreeSpace :: LPCTSTR -> Ptr DWORD -> Ptr DWORD -> Ptr DWORD -> Ptr DWORD -> IO Bool
 
-setVolumeLabel :: String -> String -> IO ()
+setVolumeLabel :: Maybe String -> Maybe String -> IO ()
 setVolumeLabel path name =
-  withTString path $ \ c_path ->
-  withTString name $ \ c_name ->
+  maybeWith withTString path $ \ c_path ->
+  maybeWith withTString name $ \ c_name ->
   failIfFalse_ "SetVolumeLabel" $ c_SetVolumeLabel c_path c_name
 foreign import WINDOWS_CCONV unsafe "windows.h SetVolumeLabelW"
   c_SetVolumeLabel :: LPCTSTR -> LPCTSTR -> IO Bool

--- a/System/Win32/HardLink.hs
+++ b/System/Win32/HardLink.hs
@@ -60,10 +60,10 @@ data VolumeInformation = VolumeInformation
       , fileSystemName     :: String
       } deriving Show
 
-getVolumeInformation :: String -> IO VolumeInformation
+getVolumeInformation :: Maybe String -> IO VolumeInformation
 getVolumeInformation drive =
-   withTString drive        $ \c_drive ->
-   withTStringBufferLen 256 $ \(vnBuf, vnLen) ->
+   maybeWith withTString drive $ \c_drive ->
+   withTStringBufferLen 256    $ \(vnBuf, vnLen) ->
    alloca $ \serialNum ->
    alloca $ \maxLen ->
    alloca $ \fsFlags ->

--- a/System/Win32/Info.hsc
+++ b/System/Win32/Info.hsc
@@ -21,7 +21,7 @@ module System.Win32.Info where
 
 import Control.Exception (catch)
 import Foreign.Marshal.Alloc (alloca)
-import Foreign.Marshal.Utils (with)
+import Foreign.Marshal.Utils (with, maybeWith)
 import Foreign.Marshal.Array (allocaArray)
 import Foreign.Ptr (Ptr, nullPtr)
 import Foreign.Storable (Storable(..))
@@ -132,11 +132,11 @@ getShortPathName name = do
     try "getShortPathName"
       (c_GetShortPathName c_name) 512
 
-searchPath :: Maybe String -> FilePath -> String -> IO (Maybe FilePath)
+searchPath :: Maybe String -> FilePath -> Maybe String -> IO (Maybe FilePath)
 searchPath path filename ext =
   maybe ($ nullPtr) withTString path $ \p_path ->
   withTString filename $ \p_filename ->
-  withTString ext      $ \p_ext ->
+  maybeWith withTString ext      $ \p_ext ->
   alloca $ \ppFilePart -> (do
     s <- try "searchPath" (\buf len -> c_SearchPath p_path p_filename p_ext
                           len buf ppFilePart) 512

--- a/System/Win32/Types.hsc
+++ b/System/Win32/Types.hsc
@@ -209,6 +209,9 @@ nullHANDLE = nullPtr
 
 type MbHANDLE      = Maybe HANDLE
 
+nullHINSTANCE :: HINSTANCE
+nullHINSTANCE = nullPtr
+
 type   HINSTANCE   = Ptr ()
 type MbHINSTANCE   = Maybe HINSTANCE
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * Make cabal error out on compilation on non-Windows OSes. (See #80)
 * Update cabal format to 1.10 and set language 
   default to Haskell2010. (See #81)
+* Use `Maybe` in wrappers for functions with nullable pointer parameters (See #84)
 
 ## 2.5.3.0 *March 2017*
 

--- a/tests/registry001.hs
+++ b/tests/registry001.hs
@@ -12,5 +12,5 @@ main = do
   k3 <- regCreateKey k2 "GHC"
   flip finally (regDeleteValue k3 name) $ do
   regSetStringValue k3 name x
-  r <- regQueryValue k3 (Just name)
+  r <- regQueryValue k3 name
   print r


### PR DESCRIPTION
This pull request is a breaking change. It addresses issue #24 opened by me.

In short, some WinAPI functions accept both `NULL` and `""` with differing result. _e.g._ `FindWindow(NULL, "Window")` means find the window with title `"Window"` and ignore the window class, while `FindWindow("", "Window")` matches an empty window class.

We have a total of 15 such functions and 12 more where allowing `NULL` has no advantage over `""`:

### Functions amended by adding `Maybe` where applicable:

|      Function      | Why pass `Nothing`?             |
|--------------------|-------------------------------|
|     appendMenu     | To associate `NULL` with the menu item when `MenuFlag & MF_OWNEDRAW` |
|     insertMenu     | To associate `NULL` with the menu item when `MenuFlag & MF_OWNEDRAW` |
|     modifyMenu     | To associate `NULL` with the menu item when `MenuFlag & MF_OWNEDRAW` |
|     messageBox     | First argument: If the MessageBox shouldn't have an owner window
|     findWindow     | If we want to search by window name xor class name
|    findWindowEx    | First argument: Use the desktop as parent window.<br>Second argument: To begin search from the first child window<br>Last two arguments: If we want to search by window name xor class name
|     moveFileEx     | To have the file deleted at restart when `MoveFileFlag & MOVEFILE_DELAY_UNTIL_REBOOT` |
|   setDllDirectory  | To restore default search order
|   defineDosDevice  | Remove a device defintion when `DefineDosDeviceFlags & DDD_REMOVE_DEFINITION`
|   setVolumeLabel   | First argument: Use current directory.<br>Second argument: Delete any existing label
|getVolumeInformation| To use root of current directory. It's commented out though
|     searchPath     | To search for the file in a registry-dependent system search path
|   regCreateKeyEx   | If there's no user-defined class type for the key
|    regReplaceKey   | If we don't want to specify a subkey
|    getTimeFormat   | First argument: Use local system time.<br>Second argument: Format according to locale

### Functions delibrately left out:

|      Function      | Why was it left out                     |
|--------------------|-----------------------------------------|
|    regCreateKey    | Passing `NULL` is a NOP (basically a memcpy from first to last param)
|   regQueryValueEx  | Passing `NULL` is a NOP (basically a memcpy from first to last param)
|     regOpenKey     | Passing `NULL` is a NOP (basically a memcpy from first to last param)
|    regOpenKeyEx    | `NULL` behavior is same as empty string behavior
|     regSetValue    | `NULL` behavior is same as empty string behavior
|    regSetValueEx   | `NULL` behavior is same as empty string behavior
|  outputDebugString | `NULL` behavior is same as empty string behavior
|    createWindow    | Second argument: `NULL` behavior is same as empty string behavior
|   createWindowEx   | Third argument: `NULL` behavior is same as empty string behavior 
|     messageBox     | Second argument: `NULL` behavior is same as empty string behavior (lpWindowName).<br>Third argument: Just a shortcut for `"Error"`

### Functions where `Maybe` was removed:

|      Function      | Why was it removed                      |
|--------------------|-----------------------------------------|
|    regQueryValue   | Behavior on `Nothing` equal to `Just ""`
|  regQueryValueKey  | Behavior on `Nothing` equal to `Just ""`

### Functions where null constants are provided

createWindow[Ex] allow the `HINSTANCE` parameter to be `NULL` in order to ignore possible local overrides. `nullHINSTANCE` is now provided for this use case.

### Functions that could be removed but weren't

|      Function      | Why could it be removed                 |
|--------------------|-----------------------------------------|
|  findWindowByName  | same as `findWindow Nothing $ Just wname`


