### PR TITLE
Add setFilePointer

### DIFF
--- a/System/Win32/File.hsc
+++ b/System/Win32/File.hsc
@@ -531,9 +531,13 @@ win32_WriteFile h buf n mb_over =
 foreign import WINDOWS_CCONV unsafe "windows.h WriteFile"
   c_WriteFile :: HANDLE -> Ptr a -> DWORD -> Ptr DWORD -> LPOVERLAPPED -> IO Bool
 
--- missing Seek functioinality; GSL ???
--- Dont have Word64; ADR
--- %fun SetFilePointer :: HANDLE -> Word64 -> FilePtrDirection -> IO Word64
+setFilePointer :: HANDLE -> LARGE_INTEGER -> FilePtrDirection -> IO LARGE_INTEGER
+setFilePointer h dist dir =
+  alloca $ \p_pos -> do
+  failIfFalse_ "SetFilePointerEx" $ c_SetFilePointerEx h dist p_pos dir
+  peek p_pos
+foreign import WINDOWS_CCONV unsafe "windows.h SetFilePointerEx"
+  c_SetFilePointerEx :: HANDLE -> LARGE_INTEGER -> Ptr LARGE_INTEGER -> FilePtrDirection -> IO Bool
 
 ----------------------------------------------------------------
 -- File Notifications

--- a/System/Win32/File.hsc
+++ b/System/Win32/File.hsc
@@ -531,8 +531,8 @@ win32_WriteFile h buf n mb_over =
 foreign import WINDOWS_CCONV unsafe "windows.h WriteFile"
   c_WriteFile :: HANDLE -> Ptr a -> DWORD -> Ptr DWORD -> LPOVERLAPPED -> IO Bool
 
-setFilePointer :: HANDLE -> LARGE_INTEGER -> FilePtrDirection -> IO LARGE_INTEGER
-setFilePointer h dist dir =
+setFilePointerEx :: HANDLE -> LARGE_INTEGER -> FilePtrDirection -> IO LARGE_INTEGER
+setFilePointerEx h dist dir =
   alloca $ \p_pos -> do
   failIfFalse_ "SetFilePointerEx" $ c_SetFilePointerEx h dist p_pos dir
   peek p_pos

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 2.6.2.0 *TBD*
 
-* Add `setFilePointer`
+* Add `setFilePointerEx`
 
 ## 2.6.1.0 *November 2017*
 
@@ -11,7 +11,7 @@
 ## 2.6.0.0 *September 2017*
 
 * Make cabal error out on compilation on non-Windows OSes. (See #80)
-* Update cabal format to 1.10 and set language 
+* Update cabal format to 1.10 and set language
   default to Haskell2010. (See #81)
 * Use `Maybe` in wrappers for functions with nullable pointer parameters (See #83)
 * Improve cross compilation support. (See #87)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog for [`Win32` package](http://hackage.haskell.org/package/Win32)
 
+## 2.6.2.0 *TBD*
+
+* Add `setFilePointer`
+
 ## 2.6.1.0 *November 2017*
 
 * Add `terminateProcessById` (See #91)


### PR DESCRIPTION
For a project of mine I need to be able to `seek` a file. 

## Description
This adds another foreign import to `SetFilePointerEx` and calls that.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have not added a new Haskell dependency.
- [x] I have included a changelog entry.
- [x] I have not modified the version of the package in `Win32.cabal`.
