### PR TITLE
Redefine DWORD_PTR as type synonym to fix #99

### DIFF
--- a/System/Win32/Types.hsc
+++ b/System/Win32/Types.hsc
@@ -99,11 +99,10 @@ type ULONG         = Word32
 type UINT_PTR      = Word
 type LONG_PTR      = CIntPtr
 type ULONG_PTR     = CUIntPtr
+type DWORD_PTR     = ULONG_PTR
 #ifdef _WIN64
 type HALF_PTR      = Ptr INT32
-type DWORD_PTR     = DWORD64
 #else
-type DWORD_PTR     = DWORD32
 type HALF_PTR      = Ptr SHORT
 #endif
 


### PR DESCRIPTION
MSDN notes: typedef ULONG_PTR DWORD_PTR;

## Description

## Motivation and Context
#99

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [Possibly?] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have not added a new Haskell dependency.
- [not needed, there's one already] I have included a changelog entry.
- [x] I have not modified the version of the package in `Win32.cabal`.
