### PR TITLE
fix MOUSEINPUT poke dx -> dy

### DIFF
--- a/System/Win32/Automation/Input/Mouse.hsc
+++ b/System/Win32/Automation/Input/Mouse.hsc
@@ -36,7 +36,7 @@ instance Storable MOUSEINPUT where
     alignment _ = #alignment MOUSEINPUT
     poke buf input = do
         (#poke MOUSEINPUT, dx) buf (dx input)
-        (#poke MOUSEINPUT, dx) buf (dx input)
+        (#poke MOUSEINPUT, dy) buf (dy input)
         (#poke MOUSEINPUT, mouseData)   buf (mouseData input)
         (#poke MOUSEINPUT, dwFlags)     buf (dwFlags input)
         (#poke MOUSEINPUT, time)        buf (time input)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I've never contributed before, so please let me know if I need to add to the changelog, bump the version, make an issue, etc.

## Description
<!--- Describe your changes in detail -->
When calling `sendInput` with a `MOUSEINPUT`, the `dy` was always ignored.

Updating `poke` from its `Storable` instance seemed to fix it.  

How I tested it:
 - `stack unpack Win32`
 - added `- ./Win32-2.7.0.0` to `extra-deps`
 - updated `System.Win32.Automation.Input.Mouse`
 - `stack build`
 - `stack ghci`
 - `import System.Win32`
 - `import qualified System.Win32.Automation.Input.Mouse as M`
 - `sendInput [Mouse $ M.MOUSEINPUT 10 10 0 M.mOUSEEVENTF_MOVE 0 0]`

before the change, it only moved left/right, now it moves diagonally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have not added a new Haskell dependency.
- [ ] I have included a changelog entry.
- [x] I have not modified the version of the package in `Win32.cabal`.
