### PR TITLE
Remove unused CPP lower bounds

### DIFF
--- a/Graphics/Win32.hs
+++ b/Graphics/Win32.hs
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/Graphics/Win32/Control.hsc
+++ b/Graphics/Win32/Control.hsc
@@ -1,6 +1,4 @@
-#if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Graphics.Win32.Control

--- a/Graphics/Win32/Dialogue.hsc
+++ b/Graphics/Win32/Dialogue.hsc
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/Graphics/Win32/GDI.hs
+++ b/Graphics/Win32/GDI.hs
@@ -1,6 +1,4 @@
-#if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Graphics.Win32.GDI

--- a/Graphics/Win32/GDI/Bitmap.hsc
+++ b/Graphics/Win32/GDI/Bitmap.hsc
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/Graphics/Win32/GDI/Brush.hsc
+++ b/Graphics/Win32/GDI/Brush.hsc
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/Graphics/Win32/GDI/Clip.hsc
+++ b/Graphics/Win32/GDI/Clip.hsc
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/Graphics/Win32/GDI/Font.hsc
+++ b/Graphics/Win32/GDI/Font.hsc
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/Graphics/Win32/GDI/Graphics2D.hs
+++ b/Graphics/Win32/GDI/Graphics2D.hs
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/Graphics/Win32/GDI/HDC.hs
+++ b/Graphics/Win32/GDI/HDC.hs
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/Graphics/Win32/GDI/Palette.hsc
+++ b/Graphics/Win32/GDI/Palette.hsc
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/Graphics/Win32/GDI/Path.hs
+++ b/Graphics/Win32/GDI/Path.hs
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/Graphics/Win32/GDI/Pen.hsc
+++ b/Graphics/Win32/GDI/Pen.hsc
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/Graphics/Win32/GDI/Region.hs
+++ b/Graphics/Win32/GDI/Region.hs
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/Graphics/Win32/GDI/Types.hsc
+++ b/Graphics/Win32/GDI/Types.hsc
@@ -1,6 +1,4 @@
-#if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Graphics.Win32.GDI.Types

--- a/Graphics/Win32/Icon.hs
+++ b/Graphics/Win32/Icon.hs
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/Graphics/Win32/Key.hsc
+++ b/Graphics/Win32/Key.hsc
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/Graphics/Win32/Menu.hsc
+++ b/Graphics/Win32/Menu.hsc
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/Graphics/Win32/Message.hsc
+++ b/Graphics/Win32/Message.hsc
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/Graphics/Win32/Misc.hsc
+++ b/Graphics/Win32/Misc.hsc
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/Graphics/Win32/Resource.hsc
+++ b/Graphics/Win32/Resource.hsc
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/Graphics/Win32/Window.hsc
+++ b/Graphics/Win32/Window.hsc
@@ -1,8 +1,6 @@
 {-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE NegativeLiterals #-}
-#if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Graphics.Win32.Window

--- a/System/Win32.hs
+++ b/System/Win32.hs
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/System/Win32/Console.hsc
+++ b/System/Win32/Console.hsc
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------
@@ -41,7 +41,7 @@ module System.Win32.Console (
 ##include "windows_cconv.h"
 
 import System.Win32.Types
-import Graphics.Win32.Misc 
+import Graphics.Win32.Misc
 
 import Foreign.C.Types (CInt(..))
 import Foreign.C.String (withCWString, CWString)

--- a/System/Win32/DLL.hsc
+++ b/System/Win32/DLL.hsc
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/System/Win32/File.hsc
+++ b/System/Win32/File.hsc
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/System/Win32/FileMapping.hsc
+++ b/System/Win32/FileMapping.hsc
@@ -1,6 +1,4 @@
-#if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  System.Win32.FileMapping
@@ -143,7 +141,7 @@ openFileMapping access inherit name =
             c_OpenFileMapping access inherit c_name
 
 mapViewOfFileEx :: HANDLE -> FileMapAccess -> DDWORD -> SIZE_T -> Ptr a -> IO (Ptr b)
-mapViewOfFileEx h access offset size base = 
+mapViewOfFileEx h access offset size base =
     failIfNull "mapViewOfFile(Ex): c_MapViewOfFileEx" $
         c_MapViewOfFileEx h access ohi olow size base
     where
@@ -162,7 +160,7 @@ foreign import WINDOWS_CCONV "windows.h OpenFileMappingW"
     c_OpenFileMapping :: DWORD -> BOOL -> LPCTSTR -> IO HANDLE
 
 foreign import WINDOWS_CCONV "windows.h CreateFileMappingW"
-    c_CreateFileMapping :: HANDLE -> Ptr () -> DWORD -> DWORD -> DWORD -> LPCTSTR -> IO HANDLE 
+    c_CreateFileMapping :: HANDLE -> Ptr () -> DWORD -> DWORD -> DWORD -> LPCTSTR -> IO HANDLE
 
 foreign import WINDOWS_CCONV "windows.h MapViewOfFileEx"
     c_MapViewOfFileEx :: HANDLE -> DWORD -> DWORD -> DWORD -> SIZE_T -> Ptr a -> IO (Ptr b)

--- a/System/Win32/Info.hsc
+++ b/System/Win32/Info.hsc
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------
@@ -360,10 +360,10 @@ type SMSetting = UINT
 
 foreign import WINDOWS_CCONV unsafe "windows.h GetUserNameW"
   c_GetUserName :: LPTSTR -> LPDWORD -> IO Bool
-  
+
 getUserName :: IO String
-getUserName =     
-  allocaArray 512 $ \ c_str -> 
+getUserName =
+  allocaArray 512 $ \ c_str ->
     with 512 $ \ c_len -> do
         failIfFalse_ "GetUserName" $ c_GetUserName c_str c_len
         len <- peek c_len

--- a/System/Win32/Mem.hsc
+++ b/System/Win32/Mem.hsc
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/System/Win32/MinTTY.hsc
+++ b/System/Win32/MinTTY.hsc
@@ -2,7 +2,7 @@
 
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------
@@ -153,7 +153,7 @@ objectNameInformation = #const ObjectNameInformation
 
 type F_NtQueryObject = HANDLE -> CInt -> Ptr OBJECT_NAME_INFORMATION
                      -> ULONG -> Ptr ULONG -> IO NTSTATUS
-                     
+
 foreign import WINDOWS_CCONV "dynamic"
   mk_NtQueryObject :: FunPtr F_NtQueryObject -> F_NtQueryObject
 

--- a/System/Win32/NLS.hsc
+++ b/System/Win32/NLS.hsc
@@ -1,6 +1,4 @@
-#if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  System.Win32.NLS

--- a/System/Win32/Path.hsc
+++ b/System/Win32/Path.hsc
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------
@@ -53,5 +53,5 @@ pathRelativePathTo from from_attr to to_attr =
     _ <- localFree p_AbsPath
     return path
 
-foreign import WINDOWS_CCONV unsafe "Shlwapi.h PathRelativePathToW" 
+foreign import WINDOWS_CCONV unsafe "Shlwapi.h PathRelativePathToW"
          c_pathRelativePathTo :: LPTSTR -> LPCTSTR -> DWORD -> LPCTSTR -> DWORD -> IO UINT

--- a/System/Win32/Process.hsc
+++ b/System/Win32/Process.hsc
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/System/Win32/Registry.hsc
+++ b/System/Win32/Registry.hsc
@@ -1,6 +1,4 @@
-#if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  System.Win32.Registry

--- a/System/Win32/Security.hsc
+++ b/System/Win32/Security.hsc
@@ -5,9 +5,7 @@
 --     http://hackage.haskell.org/trac/ghc/wiki/WorkingConventions#Warnings
 -- for details
 
-#if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  System.Win32.Security
@@ -22,7 +20,7 @@
 --
 -----------------------------------------------------------------------------
 
-module System.Win32.Security ( 
+module System.Win32.Security (
         -- * Types
         SID, PSID,
         ACL, PACL,
@@ -96,34 +94,34 @@ foreign import WINDOWS_CCONV unsafe "windows.h GetSecurityDescriptorControl"
     :: PSECURITY_DESCRIPTOR -- pSecurityDescriptor
     -> Ptr SECURITY_DESCRIPTOR_CONTROL -- pControl
     -> LPDWORD -- lpdwRevision
-    -> IO BOOL 
+    -> IO BOOL
 
 foreign import WINDOWS_CCONV unsafe "windows.h GetSecurityDescriptorDacl"
-  c_getSecurityDescriptorDacl 
+  c_getSecurityDescriptorDacl
     :: PSECURITY_DESCRIPTOR -- pSecurityDescriptor
     -> LPBOOL -- lpbDaclPresent
     -> Ptr PACL -- pDacl
     -> LPBOOL -- lpbDaclDefaulted
-    -> IO BOOL 
+    -> IO BOOL
 
 foreign import WINDOWS_CCONV unsafe "windows.h GetSecurityDescriptorGroup"
   c_getSecurityDescriptorGroup
     :: PSECURITY_DESCRIPTOR -- pSecurityDescriptor
     -> Ptr PSID -- pGroup
     -> LPBOOL -- lpbGroupDefaulted
-    -> IO BOOL 
+    -> IO BOOL
 
 foreign import WINDOWS_CCONV unsafe "windows.h GetSecurityDescriptorLength"
   c_getSecurityDescriptorLength
     :: PSECURITY_DESCRIPTOR -- pSecurityDescriptor
-    -> IO DWORD 
+    -> IO DWORD
 
 foreign import WINDOWS_CCONV unsafe "windows.h GetSecurityDescriptorOwner"
   c_getSecurityDescriptorOwner
     :: PSECURITY_DESCRIPTOR -- pSecurityDescriptor
     -> Ptr PSID -- pOwner
     -> LPBOOL -- lpbOwnerDefaulted
-    -> IO BOOL 
+    -> IO BOOL
 
 foreign import WINDOWS_CCONV unsafe "windows.h GetSecurityDescriptorSacl"
   c_getSecurityDescriptorSacl
@@ -131,18 +129,18 @@ foreign import WINDOWS_CCONV unsafe "windows.h GetSecurityDescriptorSacl"
     -> LPBOOL -- lpbSaclPresent
     -> Ptr PACL -- pSacl
     -> LPBOOL -- lpbSaclDefaulted
-    -> IO BOOL 
+    -> IO BOOL
 
 foreign import WINDOWS_CCONV unsafe "windows.h InitializeSecurityDescriptor"
   c_initializeSecurityDescriptor
     :: PSECURITY_DESCRIPTOR -- pSecurityDescriptor
     -> DWORD -- dwRevision
-    -> IO BOOL 
+    -> IO BOOL
 
 foreign import WINDOWS_CCONV unsafe "windows.h IsValidSecurityDescriptor"
   c_isValidSecurityDescriptor
     :: PSECURITY_DESCRIPTOR -- pSecurityDescriptor
-    -> IO BOOL 
+    -> IO BOOL
 
 foreign import WINDOWS_CCONV unsafe "windows.h SetSecurityDescriptorDacl"
   c_setSecurityDescriptorDacl
@@ -150,21 +148,21 @@ foreign import WINDOWS_CCONV unsafe "windows.h SetSecurityDescriptorDacl"
     -> BOOL -- bDaclPresent
     -> PACL -- pDacl
     -> BOOL -- bDaclDefaulted
-    -> IO BOOL 
+    -> IO BOOL
 
 foreign import WINDOWS_CCONV unsafe "windows.h SetSecurityDescriptorGroup"
   c_setSecurityDescriptorGroup
     :: PSECURITY_DESCRIPTOR -- pSecurityDescriptor
     -> PSID -- pGroup
     -> BOOL -- bGroupDefaulted
-    -> IO BOOL 
+    -> IO BOOL
 
 foreign import WINDOWS_CCONV unsafe "windows.h SetSecurityDescriptorOwner"
   c_setSecurityDescriptorOwner
     :: PSECURITY_DESCRIPTOR -- pSecurityDescriptor
     -> PSID -- pOwner
     -> BOOL -- bOwnerDefaulted
-    -> IO BOOL 
+    -> IO BOOL
 
 foreign import WINDOWS_CCONV unsafe "windows.h SetSecurityDescriptorSacl"
   c_setSecurityDescriptorSacl
@@ -172,7 +170,7 @@ foreign import WINDOWS_CCONV unsafe "windows.h SetSecurityDescriptorSacl"
     -> BOOL -- bSaclPresent
     -> PACL -- pSacl
     -> BOOL -- bSaclDefaulted
-    -> IO BOOL 
+    -> IO BOOL
 
 -- ---------------------------------------------------------------------------
 
@@ -190,7 +188,7 @@ type SECURITY_INFORMATION = DWORD
 -- , pROTECTED_DACL_SECURITY_INFORMATION = PROTECTED_DACL_SECURITY_INFORMATION
 -- , pROTECTED_SACL_SECURITY_INFORMATION = PROTECTED_SACL_SECURITY_INFORMATION
 -- , uNPROTECTED_DACL_SECURITY_INFORMATION = UNPROTECTED_DACL_SECURITY_INFORMATION
--- , uNPROTECTED_SACL_SECURITY_INFORMATION = UNPROTECTED_SACL_SECURITY_INFORMATION 
+-- , uNPROTECTED_SACL_SECURITY_INFORMATION = UNPROTECTED_SACL_SECURITY_INFORMATION
 
 getFileSecurity
     :: String
@@ -203,7 +201,7 @@ getFileSecurity filename si =
   needed <- peek lpnLengthNeeded
   fpSd <- mallocForeignPtrBytes (fromIntegral needed)
   withForeignPtr fpSd $ \pSd -> do
-  failIfFalse_ "getFileSecurity" $ 
+  failIfFalse_ "getFileSecurity" $
     c_GetFileSecurity lpFileName si pSd needed lpnLengthNeeded
   return (SecurityDescriptor fpSd)
 
@@ -214,7 +212,7 @@ foreign import WINDOWS_CCONV unsafe "windows.h GetFileSecurityW"
     -> PSECURITY_DESCRIPTOR -- pSecurityDescriptor
     -> DWORD -- nLength
     -> LPDWORD -- lpnLengthNeeded
-    -> IO BOOL 
+    -> IO BOOL
 
 --foreign import WINDOWS_CCONV unsafe "windows.h AccessCheck"
 --  c_AccessCheck

--- a/System/Win32/Shell.hsc
+++ b/System/Win32/Shell.hsc
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------
@@ -81,7 +81,7 @@ sHGetFolderPath hwnd csidl hdl flags =
     peekTString pstr
 
 raiseUnsupported :: String -> IO ()
-raiseUnsupported loc = 
+raiseUnsupported loc =
    ioError (ioeSetErrorString (mkIOError illegalOperationErrorType loc Nothing Nothing) "unsupported operation")
 
 foreign import WINDOWS_CCONV unsafe "SHGetFolderPathW"

--- a/System/Win32/SimpleMAPI.hsc
+++ b/System/Win32/SimpleMAPI.hsc
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------
@@ -224,7 +224,7 @@ mapiLogon f hwnd ses pw flags =
     maybeWith withCAString pw   $ \c_pw  ->
     alloca                      $ \out   -> do
         mapiFail_ "MAPILogon: " $ mapifLogon
-            f (maybeHWND hwnd) 
+            f (maybeHWND hwnd)
             c_ses c_pw flags 0 out
         peek out
 

--- a/System/Win32/Time.hsc
+++ b/System/Win32/Time.hsc
@@ -1,6 +1,6 @@
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 701
+#else
 {-# LANGUAGE Trustworthy #-}
 #endif
 -----------------------------------------------------------------------------

--- a/System/Win32/Types.hsc
+++ b/System/Win32/Types.hsc
@@ -1,7 +1,5 @@
-#if __GLASGOW_HASKELL__ >= 701
-{-# LANGUAGE Trustworthy #-}
-#endif
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE Trustworthy #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  System.Win32.Types


### PR DESCRIPTION
`Win32` currently supports GHC 7.4 as the minimum, so many checks of the form `#if __GLASGOW_HASKELL__ >= 701` are never reached. Let's remove them.