### PR TITLE
Drop use of NegativeLiterals (fixes #118)

### DIFF
--- a/Graphics/Win32/Window.hsc
+++ b/Graphics/Win32/Window.hsc
@@ -1,5 +1,4 @@
 {-# LANGUAGE CApiFFI #-}
-{-# LANGUAGE NegativeLiterals #-}
 {-# LANGUAGE Trustworthy #-}
 -----------------------------------------------------------------------------
 -- |
@@ -682,7 +681,7 @@ allocaMessage = allocaBytes #{size MSG}
 
 getMessage :: LPMSG -> Maybe HWND -> IO Bool
 getMessage msg mb_wnd = do
-  res <- failIf (== -1) "GetMessage" $
+  res <- failIf (== maxBound) "GetMessage" $
     c_GetMessage msg (maybePtr mb_wnd) 0 0
   return (res /= 0)
 foreign import WINDOWS_CCONV "windows.h GetMessageW"
@@ -694,7 +693,7 @@ foreign import WINDOWS_CCONV "windows.h GetMessageW"
 
 peekMessage :: LPMSG -> Maybe HWND -> UINT -> UINT -> UINT -> IO ()
 peekMessage msg mb_wnd filterMin filterMax remove = do
-  failIf_ (== -1) "PeekMessage" $
+  failIf_ (== maxBound) "PeekMessage" $
     c_PeekMessage msg (maybePtr mb_wnd) filterMin filterMax remove
 foreign import WINDOWS_CCONV "windows.h PeekMessageW"
   c_PeekMessage :: LPMSG -> HWND -> UINT -> UINT -> UINT -> IO LONG

--- a/Win32.cabal
+++ b/Win32.cabal
@@ -1,5 +1,5 @@
 name:		Win32
-version:	2.8.1.0
+version:	2.8.2.0
 license:	BSD3
 license-file:	LICENSE
 author:		Alastair Reid, shelarcy, Tamar Christina

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog for [`Win32` package](http://hackage.haskell.org/package/Win32)
 
+## 2.8.2.0 *Dec 2018*
+
+* Drop use of NegativeLiterals (See #118)
+
 ## 2.8.1.0 *Nov 2018*
 
 * Fix broken links (See #116)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Drops the use of the NegativeLiterals extension

## Motivation and Context
Fixes support for GHC 7.6.x

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have not added a new Haskell dependency.
- [x] I have included a changelog entry.
- [ ] I have not modified the version of the package in `Win32.cabal`.
