### PR TITLE
Add Basic Support for DLL modules from Process memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Specific generated files
+.cabal-sandbox/
 GNUmakefile
 ghc.mk
 dist/

--- a/System/Win32/Process.hsc
+++ b/System/Win32/Process.hsc
@@ -24,10 +24,11 @@ import Foreign               ( Ptr, peekByteOff, allocaBytes, pokeByteOff
                              , plusPtr )
 import Foreign.C.Types       ( CUInt(..) )
 import System.Win32.File     ( closeHandle )
-import System.Win32.DebugApi (ForeignAddress)
+import System.Win32.DebugApi ( ForeignAddress )
 import System.Win32.Types
 
 ##include "windows_cconv.h"
+##include "tlhelp32_compat.h"
 
 #include <windows.h>
 #include <tlhelp32.h>
@@ -177,7 +178,6 @@ th32SnapEnumModules h = allocaBytes (#size MODULEENTRY32W) $ \pe -> do
         readAndNext ok pe res
             | not ok    = do
                 err <- getLastError
-                print err
                 if err == (#const ERROR_NO_MORE_FILES)
                     then return $ reverse res
                     else failWith "th32SnapEnumModules: Module32First/Module32Next" err

--- a/System/Win32/Process.hsc
+++ b/System/Win32/Process.hsc
@@ -18,12 +18,13 @@
 -----------------------------------------------------------------------------
 
 module System.Win32.Process where
-import Control.Exception    ( bracket )
-import Control.Monad        ( liftM5 )
-import Foreign              ( Ptr, peekByteOff, allocaBytes, pokeByteOff
-                            , plusPtr )
-import Foreign.C.Types      ( CUInt(..) )
-import System.Win32.File    ( closeHandle )
+import Control.Exception     ( bracket )
+import Control.Monad         ( liftM5 )
+import Foreign               ( Ptr, peekByteOff, allocaBytes, pokeByteOff
+                             , plusPtr )
+import Foreign.C.Types       ( CUInt(..) )
+import System.Win32.File     ( closeHandle )
+import System.Win32.DebugApi (ForeignAddress)
 import System.Win32.Types
 
 ##include "windows_cconv.h"
@@ -37,7 +38,6 @@ iNFINITE = #{const INFINITE}
 
 foreign import WINDOWS_CCONV unsafe "windows.h Sleep"
   sleep :: DWORD -> IO ()
-
 
 type ProcessId = DWORD
 type ProcessHandle = HANDLE
@@ -58,7 +58,6 @@ type ProcessAccessRights = DWORD
 
 foreign import WINDOWS_CCONV unsafe "windows.h OpenProcess"
     c_OpenProcess :: ProcessAccessRights -> BOOL -> ProcessId -> IO ProcessHandle
-
 
 openProcess :: ProcessAccessRights -> BOOL -> ProcessId -> IO ProcessHandle
 openProcess r inh i = failIfNull "OpenProcess" $ c_OpenProcess r inh i
@@ -94,11 +93,14 @@ type Th32SnapHandle = HANDLE
 type Th32SnapFlags = DWORD
 -- | ProcessId, number of threads, parent ProcessId, process base priority, path of executable file
 type ProcessEntry32 = (ProcessId, Int, ProcessId, LONG, String)
+type ModuleEntry32 = (ForeignAddress, Int, HMODULE, String, String)
 
 #{enum Th32SnapFlags,
     , tH32CS_SNAPALL        = TH32CS_SNAPALL
     , tH32CS_SNAPHEAPLIST   = TH32CS_SNAPHEAPLIST
     , tH32CS_SNAPMODULE     = TH32CS_SNAPMODULE
+    , tH32CS_SNAPMODULE32   = TH32CS_SNAPMODULE32
+    , tH32CS_SNAPMODULE64   = (TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32)
     , tH32CS_SNAPPROCESS    = TH32CS_SNAPPROCESS
     , tH32CS_SNAPTHREAD     = TH32CS_SNAPTHREAD
     }
@@ -116,6 +118,12 @@ foreign import WINDOWS_CCONV unsafe "tlhelp32.h Process32FirstW"
 foreign import WINDOWS_CCONV unsafe "tlhelp32.h Process32NextW"
     c_Process32Next :: Th32SnapHandle -> Ptr ProcessEntry32 -> IO BOOL
 
+foreign import WINDOWS_CCONV unsafe "tlhelp32.h Module32FirstW"
+    c_Module32First :: Th32SnapHandle -> Ptr ModuleEntry32 -> IO BOOL
+
+foreign import WINDOWS_CCONV unsafe "tlhelp32.h Module32NextW"
+    c_Module32Next :: Th32SnapHandle -> Ptr ModuleEntry32 -> IO BOOL
+
 -- | Create a snapshot of specified resources.  Call closeHandle to close snapshot.
 createToolhelp32Snapshot :: Th32SnapFlags -> Maybe ProcessId -> IO Th32SnapHandle
 createToolhelp32Snapshot f p
@@ -125,7 +133,6 @@ createToolhelp32Snapshot f p
 withTh32Snap :: Th32SnapFlags -> Maybe ProcessId -> (Th32SnapHandle -> IO a) -> IO a
 withTh32Snap f p = bracket (createToolhelp32Snapshot f p) (closeHandle)
 
-
 peekProcessEntry32 :: Ptr ProcessEntry32 -> IO ProcessEntry32
 peekProcessEntry32 buf = liftM5 (,,,,)
     ((#peek PROCESSENTRY32W, th32ProcessID) buf)
@@ -133,6 +140,14 @@ peekProcessEntry32 buf = liftM5 (,,,,)
     ((#peek PROCESSENTRY32W, th32ParentProcessID) buf)
     ((#peek PROCESSENTRY32W, pcPriClassBase) buf)
     (peekTString $ (#ptr PROCESSENTRY32W, szExeFile) buf)
+
+peekModuleEntry32 :: Ptr ModuleEntry32 -> IO ModuleEntry32
+peekModuleEntry32 buf = liftM5 (,,,,)
+    ((#peek MODULEENTRY32W, modBaseAddr) buf)
+    ((#peek MODULEENTRY32W, modBaseSize) buf)
+    ((#peek MODULEENTRY32W, hModule) buf)
+    (peekTString $ (#ptr MODULEENTRY32W, szModule) buf)
+    (peekTString $ (#ptr MODULEENTRY32W, szExePath) buf)
 
 -- | Enumerate processes using Process32First and Process32Next
 th32SnapEnumProcesses :: Th32SnapHandle -> IO [ProcessEntry32]
@@ -150,4 +165,23 @@ th32SnapEnumProcesses h = allocaBytes (#size PROCESSENTRY32W) $ \pe -> do
             | otherwise = do
                 entry <- peekProcessEntry32 pe
                 ok' <- c_Process32Next h pe
+                readAndNext ok' pe (entry:res)
+
+-- | Enumerate moduless using Module32First and Module32Next
+th32SnapEnumModules :: Th32SnapHandle -> IO [ModuleEntry32]
+th32SnapEnumModules h = allocaBytes (#size MODULEENTRY32W) $ \pe -> do
+    (#poke MODULEENTRY32W, dwSize) pe ((#size MODULEENTRY32W)::DWORD)
+    ok <- c_Module32First h pe
+    readAndNext ok pe []
+    where
+        readAndNext ok pe res
+            | not ok    = do
+                err <- getLastError
+                print err
+                if err == (#const ERROR_NO_MORE_FILES)
+                    then return $ reverse res
+                    else failWith "th32SnapEnumModules: Module32First/Module32Next" err
+            | otherwise = do
+                entry <- peekModuleEntry32 pe
+                ok' <- c_Module32Next h pe
                 readAndNext ok' pe (entry:res)

--- a/Win32.cabal
+++ b/Win32.cabal
@@ -105,7 +105,7 @@ Library
     ghc-options:      -Wall
     include-dirs:     include
     includes:         "alphablend.h", "diatemp.h", "dumpBMP.h", "ellipse.h", "errors.h", "HsGDI.h", "HsWin32.h", "Win32Aux.h", "win32debug.h", "windows_cconv.h", "WndProc.h", "alignment.h"
-    install-includes: "HsWin32.h", "HsGDI.h", "WndProc.h", "windows_cconv.h", "alphablend.h", "winternl_compat.h", "winuser_compat.h", "winreg_compat.h"
+    install-includes: "HsWin32.h", "HsGDI.h", "WndProc.h", "windows_cconv.h", "alphablend.h", "winternl_compat.h", "winuser_compat.h", "winreg_compat.h", "tlhelp32_compat.h"
     c-sources:
         cbits/HsGDI.c
         cbits/HsWin32.c

--- a/include/tlhelp32_compat.h
+++ b/include/tlhelp32_compat.h
@@ -1,0 +1,15 @@
+#ifndef TLHELP32_COMPAT_H
+#define TLHELP32_COMPAT_H
+ /*
+ * tlhelp32.h is not included in MinGW, which was shipped with the 32-bit
+ * Windows version of GHC prior to the 7.10.3 release.
+ */
+#if __GLASGOW_HASKELL__ > 708
+#else
+// Some declarations from tlhelp32.h that we need in Win32
+#include <windows.h>
+
+#define TH32CS_SNAPMODULE32 0x00000010
+
+#endif
+#endif /* TLHELP32_COMPAT_H */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Extended `System.Win32.Proccess` to include `Module32FirstW`/`Module32NextW`
## Description
<!--- Describe your changes in detail -->
Also added a `th32SnapEnumModules` function as a sister to `th32SnapEnumProcesses`
Also added `tlhelp32_compat.h` file for older GHC versions. 
Also extended `Th32SnapFlags` with official `TH32CS_SNAPMODULE32`, added `tH32CS_SNAPMODULE64` to add back `tH32CS_SNAPGETALLMODS`.
Unsure whether this is the best type for `ModuleEntry32`
```hs
type ModuleEntry32 = (ForeignAddress, Int, HMODULE, String, String)
```
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I needed these for a project of my own. Other people might find them convenient rather than having to fork the library.
<!--- If it fixes an open issue, please link to the issue here. -->
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ :x: ] Bug fix (non-breaking change which fixes an issue)
- [ :heavy_check_mark: ] New feature (non-breaking change which adds functionality)
- [ :x: ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have not added a new Haskell dependency.
- [ ] I have included a changelog entry.
- [x] I have not modified the version of the package in `Win32.cabal`.
