### PR TITLE
Fix problem with RemoveDirectory

### DIFF
--- a/System/Win32/File.hsc
+++ b/System/Win32/File.hsc
@@ -414,9 +414,13 @@ foreign import WINDOWS_CCONV unsafe "windows.h CreateDirectoryExW"
 
 removeDirectory :: String -> IO ()
 removeDirectory name =
-  withTString name $ \ c_name ->
-  failIfFalseWithRetry_ (unwords ["RemoveDirectory",show name]) $
-    c_RemoveDirectory c_name
+  withTString name $ \ c_name -> do
+      failIfFalseWithRetry_ (unwords ["RemoveDirectory",show name]) $
+        c_RemoveDirectory c_name
+      -- If the directory is open the RemoveDirectory API will remove it and
+      -- return success however an immediate call to RemoveDirectory for the
+      -- parent directory will fail with "The directory is not empty." error.
+      threadDelay 100
 foreign import WINDOWS_CCONV unsafe "windows.h RemoveDirectoryW"
   c_RemoveDirectory :: LPCTSTR -> IO Bool
 


### PR DESCRIPTION
## Description

`RemoveDirectory` API exhibits a strange behavior when removing a
directory that is open. The directory is deleted and the API returns
success, however calling `RemoveDirectory` on the parent directory
immediately afterwards fails with `The directory is not empty.` error.
It appears that the directory deletion is completed asynchronously. This
behaviour is not documented AFAIK but is easy to reproduce:

1. Create an empty directory tree `c:\1\2`
2. Open `c:\1\2` in File Explorer
3. Run the following program:

                RemoveDirectory("c:\\1\\2")
                RemoveDirectory("c:\\1")

The second `RemoveDirectory` fails with `The directory is not empty.` even
though the directory `c:\1\2` has been removed. Adding a short delay
between `RemoveDirectory` calls makes the second call succeed. 
There is no principled way to determine right delay. Experimentally even 20 us 
was sufficient on my machine so 100 us seemed like a conservative number 
that still isn't too long.

## Motivation and Context

This problem is most apparent in `System.removeDirectoryRecursive` function which traverses a directory tree deleting files and then empty directories. If a directory is open by some process on
the system (e.g. anti-virus software) the function fails with `The directory is not empty.` error while leaving an empty directory on the system. Various Haskell projects have been plagued by low-frequency occurrence of this problem, e.g.:

haskell/cabal#3123
haskell/cabal#3126
Euterpea/Euterpea2#18



<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have not added a new Haskell dependency.
- [ ] I have included a changelog entry.
- [x] I have not modified the version of the package in `Win32.cabal`.
