### PR TITLE
Add getWindowText and getWindowTextLength functions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog for [`Win32` package](http://hackage.haskell.org/package/Win32)
 
+## 2.8.4.0 *Sep 2019*
+
+* Added function `getWindowText`
+* Added function `getWindowTextLength`
+
 ## 2.8.3.0 *Feb 2019*
 
 * Add `Module32FirstW` and `Module32NextW` (See #121)


### PR DESCRIPTION
## Description
Add getWindowText and getWindowTextLength functions to Graphics.Win32.Window module. Updated changelog.md

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have not added a new Haskell dependency.
- [x] I have included a changelog entry.
- [x] I have not modified the version of the package in `Win32.cabal`.
