### PR TITLE
removing tabs

### DIFF
--- a/Win32.cabal
+++ b/Win32.cabal
@@ -1,21 +1,21 @@
-name:		Win32
-version:	2.8.5.0
-license:	BSD3
-license-file:	LICENSE
-author:		Alastair Reid, shelarcy, Tamar Christina
-copyright:	Alastair Reid, 1999-2003; shelarcy, 2012-2013; Tamar Christina, 2016-2018
-maintainer:	Haskell Libraries <libraries@haskell.org>
+name:           Win32
+version:        2.8.5.0
+license:        BSD3
+license-file:   LICENSE
+author:         Alastair Reid, shelarcy, Tamar Christina
+copyright:      Alastair Reid, 1999-2003; shelarcy, 2012-2013; Tamar Christina, 2016-2018
+maintainer:     Haskell Libraries <libraries@haskell.org>
 bug-reports:    https://github.com/haskell/win32/issues
 homepage:       https://github.com/haskell/win32
-category:	System, Graphics
-synopsis:	A binding to Windows Win32 API.
-description:	This library contains direct bindings to the Windows Win32 APIs for Haskell.
+category:       System, Graphics
+synopsis:       A binding to Windows Win32 API.
+description:    This library contains direct bindings to the Windows Win32 APIs for Haskell.
 build-type:     Simple
 cabal-version:  >= 2.0
 extra-source-files:
-        include/diatemp.h include/dumpBMP.h include/ellipse.h include/errors.h
-        include/Win32Aux.h include/win32debug.h include/alignment.h
-        changelog.md
+    include/diatemp.h include/dumpBMP.h include/ellipse.h include/errors.h
+    include/Win32Aux.h include/win32debug.h include/alignment.h
+    changelog.md
 
 Library
     default-language: Haskell2010
@@ -28,11 +28,11 @@ Library
         build-depends: unbuildable<0
         buildable: False
 
-    build-depends:	base >= 4.5 && < 5, bytestring, filepath
+    build-depends:      base >= 4.5 && < 5, bytestring, filepath
     -- Black list hsc2hs 0.68.6 which is horribly broken.
     build-tool-depends: hsc2hs:hsc2hs > 0 && < 0.68.6 || > 0.68.6
-    ghc-options:    -Wall -fno-warn-name-shadowing
-    cc-options:     -fno-strict-aliasing
+    ghc-options:        -Wall -fno-warn-name-shadowing
+    cc-options:         -fno-strict-aliasing
     exposed-modules:
         Graphics.Win32.GDI
         Graphics.Win32.GDI.Bitmap


### PR DESCRIPTION
During build of GHC i was getting the following warning

```
Warning: libraries\Win32\Win32.cabal:16:2: Tabs used as indentation at 16:2,
17:2
```

i removed all tabs and replaced them by spaces. Also changed ident from line 16 to 18 from 8 to 4 spaces.

I didn't test this change hopefully CI will pick it up and it will be good.