### PR TITLE
tools to allow window proc to be freed

### DIFF
--- a/Graphics/Win32/LayeredWindow.hsc
+++ b/Graphics/Win32/LayeredWindow.hsc
@@ -14,13 +14,11 @@ module Graphics.Win32.LayeredWindow (module Graphics.Win32.LayeredWindow, Graphi
 import Control.Monad   ( void )
 import Data.Bits       ( (.|.) )
 import Foreign.Ptr     ( Ptr )
-import Foreign.C.Types ( CIntPtr(..) )
 import Foreign.Marshal.Utils ( with )
 import Graphics.Win32.GDI.AlphaBlend ( BLENDFUNCTION )
 import Graphics.Win32.GDI.Types      ( COLORREF, HDC, SIZE, SIZE, POINT )
-import Graphics.Win32.Window         ( WindowStyleEx, c_GetWindowLongPtr, c_SetWindowLongPtr,  )
-import System.Win32.Types ( DWORD, HANDLE, BYTE, BOOL,
-                            LONG_PTR, INT )
+import Graphics.Win32.Window         ( WindowStyleEx, c_GetWindowLongPtr, c_SetWindowLongPtr )
+import System.Win32.Types ( DWORD, HANDLE, BYTE, BOOL, INT )
 
 #include <windows.h>
 ##include "windows_cconv.h"

--- a/Graphics/Win32/LayeredWindow.hsc
+++ b/Graphics/Win32/LayeredWindow.hsc
@@ -10,7 +10,7 @@
 
    Provides LayeredWindow functionality.
 -}
-module Graphics.Win32.LayeredWindow where
+module Graphics.Win32.LayeredWindow (module Graphics.Win32.LayeredWindow, Graphics.Win32.Window.c_GetWindowLongPtr ) where
 import Control.Monad   ( void )
 import Data.Bits       ( (.|.) )
 import Foreign.Ptr     ( Ptr )
@@ -18,7 +18,7 @@ import Foreign.C.Types ( CIntPtr(..) )
 import Foreign.Marshal.Utils ( with )
 import Graphics.Win32.GDI.AlphaBlend ( BLENDFUNCTION )
 import Graphics.Win32.GDI.Types      ( COLORREF, HDC, SIZE, SIZE, POINT )
-import Graphics.Win32.Window         ( WindowStyleEx, c_SetWindowLongPtr,  )
+import Graphics.Win32.Window         ( WindowStyleEx, c_GetWindowLongPtr, c_SetWindowLongPtr,  )
 import System.Win32.Types ( DWORD, HANDLE, BYTE, BOOL,
                             LONG_PTR, INT )
 
@@ -52,16 +52,9 @@ foreign import WINDOWS_CCONV unsafe "windows.h GetLayeredWindowAttributes"
 foreign import WINDOWS_CCONV unsafe "windows.h UpdateLayeredWindow"
   c_UpdateLayeredWindow :: HANDLE -> HDC -> Ptr POINT -> Ptr SIZE ->  HDC -> Ptr POINT -> COLORREF -> Ptr BLENDFUNCTION -> DWORD -> IO BOOL
 
-#if defined(x86_64_HOST_ARCH)
-foreign import WINDOWS_CCONV "windows.h GetWindowLongPtrW"
-  c_GetWindowLongPtr :: HANDLE -> INT -> IO LONG_PTR
-#else
-foreign import WINDOWS_CCONV "windows.h GetWindowLongW"
-  c_GetWindowLongPtr :: HANDLE -> INT -> IO LONG_PTR
-#endif
-
 #{enum DWORD,
  , uLW_ALPHA    = ULW_ALPHA
  , uLW_COLORKEY = ULW_COLORKEY
  , uLW_OPAQUE   = ULW_OPAQUE
  }
+

--- a/Graphics/Win32/Window.hsc
+++ b/Graphics/Win32/Window.hsc
@@ -36,7 +36,8 @@ import Graphics.Win32.Message (WindowMessage, wM_NCDESTROY)
 import System.IO.Unsafe (unsafePerformIO)
 import System.Win32.Types (ATOM, maybePtr, newTString, ptrToMaybe, numToMaybe)
 import System.Win32.Types (Addr, BOOL, DWORD, INT, LONG, LRESULT, UINT, WPARAM)
-import System.Win32.Types (HINSTANCE, LPARAM, LPCTSTR, LPTSTR, LPVOID, withTString, peekTString)
+import System.Win32.Types (HANDLE, HINSTANCE, LONG_PTR, LPARAM, LPCTSTR)
+import System.Win32.Types (LPTSTR, LPVOID, withTString, peekTString)
 import System.Win32.Types (failIf, failIf_, failIfFalse_, failIfNull, maybeNum, failUnlessSuccess, getLastError, errorWin)
 
 ##include "windows_cconv.h"
@@ -240,6 +241,17 @@ foreign import WINDOWS_CCONV unsafe "windows.h SetWindowLongPtrW"
 # error Unknown mingw32 arch
 #endif
   c_SetWindowLongPtr :: HWND -> INT -> Ptr LONG -> IO (Ptr LONG)
+
+#if defined(x86_64_HOST_ARCH)
+foreign import WINDOWS_CCONV "windows.h GetWindowLongPtrW"
+  c_GetWindowLongPtr :: HANDLE -> INT -> IO LONG_PTR
+#elif defined(x86_64_HOST_ARCH)
+foreign import WINDOWS_CCONV "windows.h GetWindowLongW"
+  c_GetWindowLongPtr :: HANDLE -> INT -> IO LONG_PTR
+#else
+# error Unknown mingw32 arch
+#endif
+
 
 -- | Creates a window with a default extended window style. If you create many
 -- windows over the life of your program, WindowClosure may leak memory. Be

--- a/Graphics/Win32/Window.hsc
+++ b/Graphics/Win32/Window.hsc
@@ -242,15 +242,14 @@ foreign import WINDOWS_CCONV unsafe "windows.h SetWindowLongPtrW"
 #endif
   c_SetWindowLongPtr :: HWND -> INT -> Ptr LONG -> IO (Ptr LONG)
 
-#if defined(x86_64_HOST_ARCH)
-foreign import WINDOWS_CCONV "windows.h GetWindowLongPtrW"
-  c_GetWindowLongPtr :: HANDLE -> INT -> IO LONG_PTR
+#if defined(i386_HOST_ARCH)
+foreign import WINDOWS_CCONV unsafe "windows.h GetWindowLongW"
 #elif defined(x86_64_HOST_ARCH)
-foreign import WINDOWS_CCONV "windows.h GetWindowLongW"
-  c_GetWindowLongPtr :: HANDLE -> INT -> IO LONG_PTR
+foreign import WINDOWS_CCONV unsafe "windows.h GetWindowLongPtrW"
 #else
 # error Unknown mingw32 arch
 #endif
+  c_GetWindowLongPtr :: HANDLE -> INT -> IO LONG_PTR
 
 
 -- | Creates a window with a default extended window style. If you create many

--- a/Graphics/Win32/Window.hsc
+++ b/Graphics/Win32/Window.hsc
@@ -16,7 +16,7 @@
 
 module Graphics.Win32.Window where
 
-import Control.Monad (liftM)
+import Control.Monad (liftM, when, unless)
 import Data.Maybe (fromMaybe)
 import Data.Int (Int32)
 import Foreign.ForeignPtr (withForeignPtr)
@@ -24,6 +24,7 @@ import Foreign.Marshal.Utils (maybeWith)
 import Foreign.Marshal.Alloc (allocaBytes)
 import Foreign.Marshal.Array (allocaArray)
 import Foreign.Ptr (FunPtr, Ptr, castFunPtrToPtr, castPtr, nullPtr)
+import Foreign.Ptr (intPtrToPtr, castPtrToFunPtr, freeHaskellFunPtr)
 import Foreign.Storable (pokeByteOff)
 import Foreign.C.Types (CIntPtr(..))
 import Graphics.Win32.GDI.Types (HBITMAP, HCURSOR, HDC, HDWP, HRGN, HWND, PRGN)
@@ -31,7 +32,7 @@ import Graphics.Win32.GDI.Types (HBRUSH, HICON, HMENU, prim_ChildWindowFromPoint
 import Graphics.Win32.GDI.Types (LPRECT, RECT, allocaRECT, peekRECT, withRECT)
 import Graphics.Win32.GDI.Types (POINT, allocaPOINT, peekPOINT, withPOINT)
 import Graphics.Win32.GDI.Types (prim_ChildWindowFromPointEx)
-import Graphics.Win32.Message (WindowMessage)
+import Graphics.Win32.Message (WindowMessage, wM_NCDESTROY)
 import System.IO.Unsafe (unsafePerformIO)
 import System.Win32.Types (ATOM, maybePtr, newTString, ptrToMaybe, numToMaybe)
 import System.Win32.Types (Addr, BOOL, DWORD, INT, LONG, LRESULT, UINT, WPARAM)
@@ -202,12 +203,24 @@ type WindowClosure = HWND -> WindowMessage -> WPARAM -> LPARAM -> IO LRESULT
 foreign import WINDOWS_CCONV "wrapper"
   mkWindowClosure :: WindowClosure -> IO (FunPtr WindowClosure)
 
-setWindowClosure :: HWND -> WindowClosure -> IO ()
+-- | The standard C wndproc for every window class registered by
+-- 'registerClass' is a C function pointer provided with this library. It in
+-- turn delegates to a Haskell function pointer stored in 'gWLP_USERDATA'.
+-- This action creates that function pointer. All Haskell function pointers
+-- must be freed in order to allow the objects they close over to be garbage
+-- collected. Consequently, if you are replacing a window closure previously
+-- set via this method or indirectly with 'createWindow' or 'createWindowEx'
+-- you must free it. This action returns a function pointer to the old window
+-- closure for you to free. The current window closure is freed automatically
+-- by 'defWindowProc' when it receives 'wM_NCDESTROY'.
+setWindowClosure :: HWND -> WindowClosure -> IO (Maybe (FunPtr WindowClosure))
 setWindowClosure wnd closure = do
   fp <- mkWindowClosure closure
-  _ <- c_SetWindowLongPtr wnd (#{const GWLP_USERDATA})
+  fpOld <- c_SetWindowLongPtr wnd (#{const GWLP_USERDATA})
                               (castPtr (castFunPtrToPtr fp))
-  return ()
+  if fpOld == nullPtr 
+     then return Nothing
+     else return $ Just $ castPtrToFunPtr fpOld
 
 {- Note [SetWindowLongPtrW]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -228,6 +241,10 @@ foreign import WINDOWS_CCONV unsafe "windows.h SetWindowLongPtrW"
 #endif
   c_SetWindowLongPtr :: HWND -> INT -> Ptr LONG -> IO (Ptr LONG)
 
+-- | Creates a window with a default extended window style. If you create many
+-- windows over the life of your program, WindowClosure may leak memory. Be
+-- sure to delegate to 'defWindowProc' for 'wM_NCDESTROY' and see
+-- 'defWindowProc' and 'setWindowClosure' for details.
 createWindow
   :: ClassName -> String -> WindowStyle ->
      Maybe Pos -> Maybe Pos -> Maybe Pos -> Maybe Pos ->
@@ -236,6 +253,10 @@ createWindow
 createWindow = createWindowEx 0
 -- apparently CreateWindowA/W are just macros for CreateWindowExA/W
 
+-- | Creates a window and allows your to specify the  extended window style. If
+-- you create many windows over the life of your program, WindowClosure may
+-- leak memory. Be sure to delegate to 'defWindowProc' for 'wM_NCDESTROY' and see
+-- 'defWindowProc' and 'setWindowClosure' for details.
 createWindowEx
   :: WindowStyle -> ClassName -> String -> WindowStyle
   -> Maybe Pos -> Maybe Pos -> Maybe Pos -> Maybe Pos
@@ -250,7 +271,7 @@ createWindowEx estyle cname wname wstyle mb_x mb_y mb_w mb_h mb_parent mb_menu i
     c_CreateWindowEx estyle cname c_wname wstyle
       (maybePos mb_x) (maybePos mb_y) (maybePos mb_w) (maybePos mb_h)
       (maybePtr mb_parent) (maybePtr mb_menu) inst nullPtr
-  setWindowClosure wnd closure
+  _ <- setWindowClosure wnd closure
   return wnd
 foreign import WINDOWS_CCONV "windows.h CreateWindowExW"
   c_CreateWindowEx
@@ -261,11 +282,23 @@ foreign import WINDOWS_CCONV "windows.h CreateWindowExW"
 
 ----------------------------------------------------------------
 
+-- | Delegates to the standard default window procedure, but if it receives the
+-- 'wM_NCDESTROY' message it first frees the window closure to allow the
+-- closure and any objects it closes over to be garbage collected. 'wM_NCDESTROY' is
+-- the last message a window receives prior to being deleted.
 defWindowProc :: Maybe HWND -> WindowMessage -> WPARAM -> LPARAM -> IO LRESULT
-defWindowProc mb_wnd msg w l =
+defWindowProc mb_wnd msg w l = do
+  when (msg == wM_NCDESTROY) (maybe (return ()) freeWindowProc mb_wnd)
   c_DefWindowProc (maybePtr mb_wnd) msg w l
 foreign import WINDOWS_CCONV "windows.h DefWindowProcW"
   c_DefWindowProc :: HWND -> WindowMessage -> WPARAM -> LPARAM -> IO LRESULT
+
+freeWindowProc :: HWND -> IO ()
+freeWindowProc hwnd = do
+   fp <- c_GetWindowLongPtr hwnd (#{const GWLP_USERDATA})
+   unless (fp == 0) $ 
+      freeHaskellFunPtr $ castPtrToFunPtr . intPtrToPtr . fromIntegral $ fp
+
 
 ----------------------------------------------------------------
 

--- a/Graphics/Win32/Window.hsc
+++ b/Graphics/Win32/Window.hsc
@@ -293,6 +293,11 @@ defWindowProc mb_wnd msg w l = do
 foreign import WINDOWS_CCONV "windows.h DefWindowProcW"
   c_DefWindowProc :: HWND -> WindowMessage -> WPARAM -> LPARAM -> IO LRESULT
 
+-- | Frees a function pointer to the window closure which has been set
+-- directly by 'setWindowClosure' or indirectly by 'createWindowEx'. You
+-- should call this function in your window closure's 'wM_NCDESTROY' case
+-- unless you delegate that case to 'defWindowProc' (e.g. as part of the
+-- default).
 freeWindowProc :: HWND -> IO ()
 freeWindowProc hwnd = do
    fp <- c_GetWindowLongPtr hwnd (#{const GWLP_USERDATA})

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 ## *Unreleased version*
 
+* `setWindowClosure` now returns the old window closure.
+* `defWindowProc` now assumes the data stored in `GWLP\_USERDATA` 
+  is the window closure (in line with `setWindowClosure` and
+  the supplied C `genericWndProc`)
+* `defWindowProc` now frees the window closure 
+
 ## 2.8.5.0 Dec 2019
 
 * Add `getConsoleMode` and `setConsoleMode` (See #137)

--- a/examples/hello.lhs
+++ b/examples/hello.lhs
@@ -53,12 +53,12 @@ freed; otherwise, lpps and onPaint action would be kept in memory.
 \begin{code}
 
 wndProc :: Graphics.Win32.LPPAINTSTRUCT
-	-> (Graphics.Win32.RECT -> Graphics.Win32.HDC -> IO ()) -- on paint action
+        -> (Graphics.Win32.RECT -> Graphics.Win32.HDC -> IO ()) -- on paint action
         -> Graphics.Win32.HWND
         -> Graphics.Win32.WindowMessage
-	-> Graphics.Win32.WPARAM
-	-> Graphics.Win32.LPARAM
-	-> IO Graphics.Win32.LRESULT
+        -> Graphics.Win32.WPARAM
+        -> Graphics.Win32.LPARAM
+        -> IO Graphics.Win32.LRESULT
 wndProc lpps onPaint hwnd wmsg wParam lParam
  | wmsg == Graphics.Win32.wM_DESTROY = do
      Graphics.Win32.sendMessage hwnd Graphics.Win32.wM_QUIT 1 0
@@ -78,26 +78,26 @@ createWindow width height wndProc = do
   bgBrush      <- Graphics.Win32.createSolidBrush (Graphics.Win32.rgb 0 0 255)
   mainInstance <- getModuleHandle Nothing
   Graphics.Win32.registerClass
-  	  ( Graphics.Win32.cS_VREDRAW + Graphics.Win32.cS_HREDRAW
-	  , mainInstance
-	  , Just icon
-	  , Just cursor
-	  , Just bgBrush
-	  , Nothing
-	  , winClass
-	  )
+          ( Graphics.Win32.cS_VREDRAW + Graphics.Win32.cS_HREDRAW
+          , mainInstance
+          , Just icon
+          , Just cursor
+          , Just bgBrush
+          , Nothing
+          , winClass
+          )
   w <- Graphics.Win32.createWindow
-  		 winClass
-		 "Hello, World example"
-		 Graphics.Win32.wS_OVERLAPPEDWINDOW
-		 Nothing Nothing -- leave it to the shell to decide the position
-		 		 -- at where to put the window initially
+                 winClass
+                 "Hello, World example"
+                 Graphics.Win32.wS_OVERLAPPEDWINDOW
+                 Nothing Nothing -- leave it to the shell to decide the position
+                                 -- at where to put the window initially
                  (Just width)
-		 (Just height)
-		 Nothing      -- no parent, i.e, root window is the parent.
-		 Nothing      -- no menu handle
-		 mainInstance
-		 wndProc
+                 (Just height)
+                 Nothing      -- no parent, i.e, root window is the parent.
+                 Nothing      -- no menu handle
+                 mainInstance
+                 wndProc
   Graphics.Win32.showWindow w Graphics.Win32.sW_SHOWNORMAL
   Graphics.Win32.updateWindow w
   return w


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Note: I have not compiled or tested this code yet so there might be some obvious bug.

## Description
<!--- Describe your changes in detail -->
This pr provides tools to the library user to ensure they can free the function pointer. Also adds some documentation to help and direct the user since our code here is not a pure wrapper around Win32.

In line with `setWindowClosure`, `withWNDCLASS`, and the supplied C `generalWndProc` procedure, it assumes that the `GWLP_USERDATA` of `SetWindowLongPtr` contains the window closure.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
All Haskell function pointers must be freed once they are disused. A function pointer is being created by setWindowClosure which is being abandoned. If more than one window is created over the life of a program, this could amount to a significant memory leak. See https://github.com/haskell/win32/issues/142

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

This change is breaking since it changes the type of `setWindowClosure` to return the existing function pointer so the user may free it. This is wholly captured in the return type. 

It also moves c_GetWindowLongPtr from Graphics.Win32.LayeredWindow, where it did not really belong, to Graphics.Win32.Window where it is in the company of its setter. But I have included an export from LayeredWindow so that if a person was importing it, they will have no incompatibility. (The return type of c_GetWindowLongPtr and c_SetWindowLongPtr are gratuitously different, but I haven't united them to avoid a needless break. I think c_GetWindowLongPtr is probably more correct.)

Otherwise, it merely introduces the new functionality and updates the example hello.lhs to use it.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have not added a new Haskell dependency.
- [x] I have included a changelog entry.
- [x] I have not modified the version of the package in `Win32.cabal`.