### PR TITLE
use -1 to test for the error condition in GetMessage and PeekMessage

### DIFF
--- a/Graphics/Win32/Window.hsc
+++ b/Graphics/Win32/Window.hsc
@@ -780,7 +780,7 @@ allocaMessage = allocaBytes #{size MSG}
 
 getMessage :: LPMSG -> Maybe HWND -> IO Bool
 getMessage msg mb_wnd = do
-  res <- failIf (== maxBound) "GetMessage" $
+  res <- failIf (== -1) "GetMessage" $
     c_GetMessage msg (maybePtr mb_wnd) 0 0
   return (res /= 0)
 foreign import WINDOWS_CCONV "windows.h GetMessageW"
@@ -792,7 +792,7 @@ foreign import WINDOWS_CCONV "windows.h GetMessageW"
 
 peekMessage :: LPMSG -> Maybe HWND -> UINT -> UINT -> UINT -> IO ()
 peekMessage msg mb_wnd filterMin filterMax remove = do
-  failIf_ (== maxBound) "PeekMessage" $
+  failIf_ (== -1) "PeekMessage" $
     c_PeekMessage msg (maybePtr mb_wnd) filterMin filterMax remove
 foreign import WINDOWS_CCONV "windows.h PeekMessageW"
   c_PeekMessage :: LPMSG -> HWND -> UINT -> UINT -> UINT -> IO LONG

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
   is the window closure (in line with `setWindowClosure` and
   the supplied C `genericWndProc`)
 * `defWindowProc` now frees the window closure 
+* `getMessage` and `peekMessage` test for -1 to identify the error condition
 
 ## 2.8.5.0 Dec 2019
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This corrects the code to once more test for -1 instead of maxBound in GetMessage and PeekMessage

## Motivation and Context
This PR would close #145. In #119 `-1` was changed to `maxBound` as part of removing the dependency on NegativeLiterals. However, NegativeLiterals does not affect the interpretation of values that can be represented as `(negate n)`. In any case, the correct value to test for is FFFF FFFF but we are presently testing for 7FFF FFFF.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have not added a new Haskell dependency.
- [x] I have included a changelog entry.
- [x] I have not modified the version of the package in `Win32.cabal`.
