### PR TITLE
Add API to create symlinks without requiring Administrator privilege

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
   the supplied C `genericWndProc`)
 * `defWindowProc` now frees the window closure 
 * `getMessage` and `peekMessage` test for -1 to identify the error condition
+* Support creating symbolic links without Administrator privilege (See #147)
 
 ## 2.8.5.0 Dec 2019
 


### PR DESCRIPTION
## Description
Adds a `Bool` argument to  `createSymbolicLinkFile`/`createSymbolicLinkDirectory` in `System.Win32.SymbolicLink`, allowing users to create symlinks without requiring Administrator privilege in the current process.

## Motivation and Context
Starting from Windows 10 version 1703 (Creators Update), after enabling Developer Mode, users can create symbolic links without requiring the Administrator privilege in the current process. See the Win32 API documentation of [`CreateSymbolicLinkW`](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createsymboliclinkw) for details.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have not added a new Haskell dependency.
- [x] I have included a changelog entry.
- [x] I have not modified the version of the package in `Win32.cabal`.
