### PR TITLE
Add `getLocaleInfoEx`, and `...Ex` functions replacing legacy ones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@
 GNUmakefile
 ghc.mk
 dist/
+dist-newstyle/
 *.hi
 *.o
 *.a
+
+# The Haskell Tool Stack-related
+.stack-work/
+stack.yaml
+stack.yaml.lock

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog for [`Win32` package](http://hackage.haskell.org/package/Win32)
 
+## Not yet released
+
+* Add `getSystemDefaultLocaleName`, `getUserDefaultLocaleName`,
+  `isValidLocaleName`, `getLocaleInfoEx`, `getTimeFormatEx` and `lCMapStringEx`
+
+* Add `trySized` - similar to `try` but for API calls that return the required size
+  of the buffer when passed a buffer size of zero.
+
 ## 2.9.1.0 September 2020
 
 * Add function `isWindowVisible`
@@ -10,10 +18,10 @@
 ## 2.9.0.0 June 2020
 
 * `setWindowClosure` now returns the old window closure.
-* `defWindowProc` now assumes the data stored in `GWLP\_USERDATA` 
+* `defWindowProc` now assumes the data stored in `GWLP\_USERDATA`
   is the window closure (in line with `setWindowClosure` and
   the supplied C `genericWndProc`)
-* `defWindowProc` now frees the window closure 
+* `defWindowProc` now frees the window closure
 * `getMessage` and `peekMessage` test for -1 to identify the error condition
 * Support creating symbolic links without Administrator privilege (See #147)
 * Support for `winio` the new Windows I/O manager.

--- a/include/alphablend.h
+++ b/include/alphablend.h
@@ -1,6 +1,6 @@
 #ifndef _ALPHABLEND_H
 #define _ALPHABLEND_H
-#define WINVER 0x0500
+
 #include <windows.h>
 
 BOOL c_AlphaBlend ( HDC hdcDest, int nXOriginDest, int nYOriginDest, int nWidthDest, int hHeightDest

--- a/include/winnls_compat.h
+++ b/include/winnls_compat.h
@@ -1,0 +1,99 @@
+/* The version of winnls.h provided by the version of MSYS2 included with
+ * versions of GHC before GHC 7.10 excludes certain components introduced with
+ * Windows Vista.
+ */
+
+#ifndef WINNLS_COMPAT_H
+#define WINNLS_COMPAT_H
+
+#if __GLASGOW_HASKELL__ < 710
+// Locale information constants
+#define LOCALE_IGEOID 0x0000005b
+#define LOCALE_SCONSOLEFALLBACKNAME 0x0000006e
+#define LOCALE_SDURATION 0x0000005d
+#define LOCALE_SENGLISHCOUNTRYNAME 0x00001002
+#define LOCALE_SENGLISHLANGUAGENAME 0x00001001
+#define LOCALE_SISO3166CTRYNAME2 0x00000068
+#define LOCALE_SISO639LANGNAME2 0x00000067
+#define LOCALE_SKEYBOARDSTOINSTALL 0x0000005e
+#define LOCALE_SNAME 0x0000005c
+#define LOCALE_SNAN 0x00000069
+#define LOCALE_SNATIVECOUNTRYNAME 0x00000008
+#define LOCALE_SNEGINFINITY 0x0000006b
+#define LOCALE_SPARENT 0x0000006d
+#define LOCALE_SPOSINFINITY 0x0000006a
+#define LOCALE_SSCRIPTS 0x0000006c
+#define LOCALE_SSHORTESTDAYNAME1 0x00000060
+#define LOCALE_SSHORTESTDAYNAME2 0x00000061
+#define LOCALE_SSHORTESTDAYNAME3 0x00000062
+#define LOCALE_SSHORTESTDAYNAME4 0x00000063
+#define LOCALE_SSHORTESTDAYNAME5 0x00000064
+#define LOCALE_SSHORTESTDAYNAME6 0x00000065
+#define LOCALE_SSHORTESTDAYNAME7 0x00000066
+// Locale map flag constants
+#define LINGUISTIC_IGNORECASE 0x00000010
+#define LINGUISTIC_IGNOREDIACRITIC 0x00000020
+#define NORM_LINGUISTIC_CASING 0x08000000
+// Other
+WINBASEAPI WINBOOL WINAPI IsValidLocaleName (LPCWSTR lpLocaleName);
+#endif
+
+#if __GLASGOW_HASKELL__ < 710 && defined(i386_HOST_ARCH)
+// Locale information constants
+#define LOCALE_IDEFAULTMACCODEPAGE 0x00001011
+// Other
+typedef struct _nlsversioninfoex {
+  DWORD dwNLSVersionInfoSize;
+  DWORD dwNLSVersion;
+  DWORD dwDefinedVersion;
+  DWORD dwEffectiveId;
+  GUID  guidCustomVersion;
+} NLSVERSIONINFOEX, *LPNLSVERSIONINFOEX;
+
+WINBASEAPI int WINAPI GetLocaleInfoEx(
+  LPCWSTR lpLocaleName,
+  LCTYPE LCType,
+  LPWSTR lpLCData,
+  int cchData
+);
+
+WINBASEAPI WINBOOL WINAPI GetNLSVersionEx(
+  NLS_FUNCTION function,
+  LPCWSTR lpLocaleName,
+  LPNLSVERSIONINFOEX lpVersionInformation
+);
+
+WINBASEAPI int WINAPI LCMapStringEx(
+  LPCWSTR lpLocaleName,
+  DWORD dwMapFlags,
+  LPCWSTR lpSrcStr,
+  int cchSrc,
+  LPWSTR lpDestStr,
+  int cchDest,
+  LPNLSVERSIONINFO lpVersionInformation,
+  LPVOID lpReserved,
+  LPARAM lParam
+);
+
+
+WINBASEAPI int WINAPI GetTimeFormatEx(
+  LPCWSTR lpLocaleName,
+  DWORD dwFlags,
+  const SYSTEMTIME *lpTime,
+  LPCWSTR lpFormat,
+  LPWSTR lpTimeStr,
+  int cchTime
+);
+
+WINBASEAPI int WINAPI GetSystemDefaultLocaleName(
+  LPWSTR lpLocaleName,
+  int cchLocaleName
+);
+
+WINBASEAPI int WINAPI GetUserDefaultLocaleName(
+  LPWSTR lpLocaleName,
+  int cchLocaleName
+);
+#endif
+
+#endif /* #ifndef WINNLS_COMPAT_H */

--- a/include/winnt_compat.h
+++ b/include/winnt_compat.h
@@ -1,0 +1,13 @@
+/* The version of winnt.h provided by the version of MSYS2 included with
+ * versions of GHC before GHC 7.10 excludes certain components introduced with
+ * Windows Vista.
+ */
+
+#ifndef WINNT_COMPAT_H
+#define WINNT_COMPAT_H
+
+#if __GLASGOW_HASKELL__ < 710 && defined(i386_HOST_ARCH)
+#define LOCALE_NAME_MAX_LENGTH 85
+#endif
+
+#endif /* #ifndef WINNT_COMPAT_H */


### PR DESCRIPTION
## Description
Adds `getLocaleInfoEx` (see https://docs.microsoft.com/en-us/windows/win32/api/winnls/nf-winnls-getlocaleinfoex).

Adds helper function `System.Win32.Utils.trySized`, similar to `try` but for API calls that return the required size of the buffer when passed a buffer size of zero (for example, `GetLocaleInfoEx`).

Consequently:

* Adds predefined locale names `lOCALE_NAME_INVARIANT`, `lOCALE_NAME_SYSTEM_DEFAULT` and `lOCALE_NAME_USER_DEFAULT`.

* Adds locale information constants used by `GetLocaleInfoEx` and adds code comments to explain why a few are omitted. (See https://docs.microsoft.com/en-us/windows/win32/intl/locale-information-constants.)

* Adds type `LCData` (with Haddock documentation) and, consequently, also types `LOCALESIGNATURE` and `UnicodeSubsetBitfield` (with Haddock documentation) (in the absense of a type for 128-bit unsigned integers).

Also adds the modern equivalents for functions already exported by the package, namely: `getSystemDefaultLocaleName` (which replaced `getSystemDefaultLCID`), `getUserDefaultLocaleName` (`getUserDefaultLCID`), `isValidLocaleName` (`isValidLocale`), `lCMapStringEx` (`lCMapString`) and `getTimeFormatEx` (`getTimeFormat`). (See https://docs.microsoft.com/en-us/windows/win32/intl/calling-the--locale-name--functions.)

Consequently:

* Adds `lOCALE_NAME_MAX_LENGTH` constant.

* Adds type synonym `NLS_FUNCTION` and type `NLSINFOVERSIONEX`. Consequently, adds type `GUID`, to avoid a dependency on, say, package `uuid-types`.

Includes a friendly `Show` instance for `GUID`, for example: {00000001-57ee-1e5c-00b4-d0000bb1e11e}.

To avoid code duplication, exports helper function `getDefaultLocaleName` (with Haddock documentation).

Also adds map flag constants used by `LCMapStringEx`. (See https://docs.microsoft.com/en-us/windows/win32/api/winnls/nf-winnls-lcmapstringex.)

Also, removes line in `alphablend.h` which forces `WINVER` to be pre-Windows Vista and adds lines to `NLS.hsc` to force `WINVER` and `_WIN32_WINNT` to be at least Windows Vista.

Also adds two compat header files, `winnt_compat.h` and `winnls_compat.h`.

Also, adds the Haskell Tool Stack artifacts and `dist-newstyle/` to `.gitignore`.

Tested by building and using on Windows 10, version 2004 (in a 'light' way, I have not tested every function with every combination of constant etc).

## Motivation and Context
I wanted to obtain information about the locale. Neither `GetLocaleInfoEx` (or its legacy equivalent, `GetLocaleInfo`) were currently catered for. Having implemented `GetLocaleInfoEx`, it seemed sensible to also implement the modern equivalents of legacy functions already exported by the package.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have not added a new Haskell dependency.
- [x] I have included a changelog entry.
- [x] I have not modified the version of the package in `Win32.cabal`.