### PR TITLE
Add `enumSystemLocalesEx`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,9 @@ matrix:
       GHCVER: 8.8.4
     - platform: x86
       GHCVER: 8.10.2
-      
+    - platform: x86_64
+      GHCVER: 8.10.2
+
 for:
   -
     matrix:

--- a/changelog.md
+++ b/changelog.md
@@ -6,10 +6,11 @@
 * Add function `getLastInputInfo`
 * Add function `getTickCount`
 * Add function `getIdleTime`
-* Add `getSystemDefaultLocaleName`, `getUserDefaultLocaleName`,
-  `isValidLocaleName`, `getLocaleInfoEx`, `getTimeFormatEx` and `lCMapStringEx`
-* Add `trySized` - similar to `try` but for API calls that return the required size
-  of the buffer when passed a buffer size of zero.
+* Add `enumSystemLocalesEx`, `enumSystemLocalesEx'`,
+  `getSystemDefaultLocaleName`, `getUserDefaultLocaleName`, `isValidLocaleName`,
+  `getLocaleInfoEx`, `getTimeFormatEx` and `lCMapStringEx`
+* Add `trySized` - similar to `try` but for API calls that return the required
+  size of the buffer when passed a buffer size of zero.
 
 ## 2.9.0.0 June 2020
 

--- a/include/winnls_compat.h
+++ b/include/winnls_compat.h
@@ -34,6 +34,12 @@
 #define LINGUISTIC_IGNORECASE 0x00000010
 #define LINGUISTIC_IGNOREDIACRITIC 0x00000020
 #define NORM_LINGUISTIC_CASING 0x08000000
+// Locale enumeration flag constants
+#define LOCALE_ALL                  0
+#define LOCALE_ALTERNATE_SORTS      0x00000004
+#define LOCALE_REPLACEMENT          0x00000008
+#define LOCALE_SUPPLEMENTAL         0x00000002
+#define LOCALE_WINDOWS              0x00000001
 // Other
 WINBASEAPI WINBOOL WINAPI IsValidLocaleName (LPCWSTR lpLocaleName);
 #endif


### PR DESCRIPTION
## Description
Adds `enumSystemLocalesEx` (see https://docs.microsoft.com/en-us/windows/win32/api/winnls/nf-winnls-enumsystemlocalesex).

Adds helper function `enumSystemLocalesEx'`, which uses a specific callback function to enumerate locale names into a value of type `[String]`.

Adds enumeration locale flag constants, and code comments to explain why one is omitted.

Extends compat header file `winnls_compat.h`.

Tested by building and using on Windows 10, version 2004.

## Motivation and Context
The package already includes functions to obtain certain locale names and information about locales by name, but does not include a binding to the function that enumerates the locale names supported by the system.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have not added a new Haskell dependency.
- [x] I have included a changelog entry.
- [x] I have not modified the version of the package in `Win32.cabal`.
