### PR TITLE
Fix typo in `isValidLocaleName` function name

### DIFF
--- a/System/Win32/NLS.hsc
+++ b/System/Win32/NLS.hsc
@@ -490,8 +490,8 @@ type LocaleTestFlags = DWORD
  , lCID_SUPPORTED       = LCID_SUPPORTED
  }
 
-isValidLocalName :: Maybe String -> IO Bool
-isValidLocalName lpLocaleName =
+isValidLocaleName :: Maybe String -> IO Bool
+isValidLocaleName lpLocaleName =
   maybeWith withTString lpLocaleName c_IsValidLocaleName
 foreign import WINDOWS_CCONV unsafe "windows.h IsValidLocaleName"
   c_IsValidLocaleName :: LPCWSTR -> IO Bool


### PR DESCRIPTION
In error, exported `isValidLocaleName` was named `isValidLocalName` in pull request #150 . This fixes that.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change) - if the package is re-released before this fix is applied.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have not added a new Haskell dependency.
- [x] I have included a changelog entry.
- [x] I have not modified the version of the package in `Win32.cabal`.
