### PR TITLE
Add Event bindings

### DIFF
--- a/System/Win32.hs
+++ b/System/Win32.hs
@@ -19,6 +19,7 @@
 
 module System.Win32
         ( module System.Win32.DLL
+        , module System.Win32.Event
         , module System.Win32.File
         , module System.Win32.FileMapping
         , module System.Win32.Info
@@ -40,6 +41,7 @@ module System.Win32
         ) where
 
 import System.Win32.DLL
+import System.Win32.Event
 import System.Win32.File
 import System.Win32.FileMapping
 import System.Win32.Info

--- a/System/Win32/Event.hsc
+++ b/System/Win32/Event.hsc
@@ -1,5 +1,3 @@
-{-# LINE 1 "System\\Win32\\Event.hsc" #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE Trustworthy #-}
 -----------------------------------------------------------------------------
 -- |

--- a/System/Win32/Event.hsc
+++ b/System/Win32/Event.hsc
@@ -24,8 +24,8 @@ import Foreign.Marshal.Utils     ( maybeWith, with )
 import Foreign.Ptr               ( Ptr, nullPtr )
 import Foreign.Storable          ( Storable(..) )
 import Graphics.Win32.Misc       ( MilliSeconds )
-import System.Win32.File         ( AccessMode )
-import System.Win32.Types        ( LPCTSTR, HANDLE, BOOL, LPVOID, withTString, failIf, failIfFalse_  )
+import System.Win32.File         ( AccessMode, LPSECURITY_ATTRIBUTES, SECURITY_ATTRIBUTES )
+import System.Win32.Types        ( LPCTSTR, HANDLE, BOOL, withTString, failIf, failIfFalse_  )
 import System.Win32.Word         ( DWORD )
 
 import qualified Data.Vector.Storable as V
@@ -58,31 +58,6 @@ type WaitResult = DWORD
     , wAIT_TIMEOUT       = WAIT_TIMEOUT
     , wAIT_FAILED        = WAIT_FAILED
     }
-
----------------------------------------------------------------------------
--- Data
----------------------------------------------------------------------------
-data SECURITY_ATTRIBUTES = SECURITY_ATTRIBUTES
-    { nLength              :: !DWORD
-    , lpSecurityDescriptor :: !LPVOID
-    , bInheritHandle       :: !BOOL
-    } deriving Show
-
-type PSECURITY_ATTRIBUTES = Ptr SECURITY_ATTRIBUTES
-type LPSECURITY_ATTRIBUTES = Ptr SECURITY_ATTRIBUTES
-
-instance Storable SECURITY_ATTRIBUTES where
-    sizeOf = const #{size SECURITY_ATTRIBUTES}
-    alignment _ = #alignment SECURITY_ATTRIBUTES
-    poke buf input = do
-        (#poke SECURITY_ATTRIBUTES, nLength)              buf (nLength input)
-        (#poke SECURITY_ATTRIBUTES, lpSecurityDescriptor) buf (lpSecurityDescriptor input)
-        (#poke SECURITY_ATTRIBUTES, bInheritHandle)       buf (bInheritHandle input)
-    peek buf = do
-        nLength              <- (#peek SECURITY_ATTRIBUTES, nLength)              buf
-        lpSecurityDescriptor <- (#peek SECURITY_ATTRIBUTES, lpSecurityDescriptor) buf
-        bInheritHandle       <- (#peek SECURITY_ATTRIBUTES, bInheritHandle)       buf
-        return SECURITY_ATTRIBUTES{..}
 
 ---------------------------------------------------------------------------
 -- API in Haskell

--- a/System/Win32/Event.hsc
+++ b/System/Win32/Event.hsc
@@ -1,0 +1,166 @@
+{-# LINE 1 "System\\Win32\\Event.hsc" #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE Trustworthy #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  System.Win32.Event
+-- Copyright   :  (c) Esa Ilari Vuokko, 2006
+-- License     :  BSD-style (see the file LICENSE)
+--
+-- Maintainer  :  Esa Ilari Vuokko <ei@vuokko.info>
+-- Stability   :  provisional
+-- Portability :  portable
+--
+-- A collection of FFI declarations for interfacing with Win32 event system between
+-- processes.
+--
+-----------------------------------------------------------------------------
+module System.Win32.Event where
+
+import Data.Vector.Storable      ( Vector )
+import Foreign.ForeignPtr        ( withForeignPtr )
+import Foreign.Marshal.Alloc     ( alloca )
+import Foreign.Marshal.Utils     ( maybeWith, with )
+import Foreign.Ptr               ( Ptr, nullPtr )
+import Foreign.Storable          ( Storable(..) )
+import Graphics.Win32.Misc       ( MilliSeconds )
+import System.Win32.File         ( AccessMode )
+import System.Win32.Types        ( LPCTSTR, HANDLE, BOOL, LPVOID, withTString, failIf, failIfFalse_  )
+import System.Win32.Word         ( DWORD )
+
+import qualified Data.Vector.Storable as V
+
+##include "windows_cconv.h"
+
+#include "windows.h"
+#include "winuser_compat.h"
+#include "alignment.h"
+
+---------------------------------------------------------------------------
+-- Enums
+---------------------------------------------------------------------------
+type DuplicateOption = DWORD
+#{enum DuplicateOption,
+    , dUPLICATE_CLOSE_SOURCE = DUPLICATE_CLOSE_SOURCE
+    , dUPLICATE_SAME_ACCESS  = DUPLICATE_SAME_ACCESS
+    }
+
+#{enum AccessMode,
+    , eVENT_ALL_ACCESS   = EVENT_ALL_ACCESS
+    , eVENT_MODIFY_STATE = EVENT_MODIFY_STATE
+    }
+
+type WaitResult = DWORD
+#{enum WaitResult,
+    , wAIT_ABANDONED     = WAIT_ABANDONED
+    , wAIT_IO_COMPLETION = WAIT_IO_COMPLETION
+    , wAIT_OBJECT_0      = WAIT_OBJECT_0
+    , wAIT_TIMEOUT       = WAIT_TIMEOUT
+    , wAIT_FAILED        = WAIT_FAILED
+    }
+
+---------------------------------------------------------------------------
+-- Data
+---------------------------------------------------------------------------
+data SECURITY_ATTRIBUTES = SECURITY_ATTRIBUTES
+    { nLength              :: !DWORD
+    , lpSecurityDescriptor :: !LPVOID
+    , bInheritHandle       :: !BOOL
+    } deriving Show
+
+type PSECURITY_ATTRIBUTES = Ptr SECURITY_ATTRIBUTES
+type LPSECURITY_ATTRIBUTES = Ptr SECURITY_ATTRIBUTES
+
+instance Storable SECURITY_ATTRIBUTES where
+    sizeOf = const #{size SECURITY_ATTRIBUTES}
+    alignment _ = #alignment SECURITY_ATTRIBUTES
+    poke buf input = do
+        (#poke SECURITY_ATTRIBUTES, nLength)              buf (nLength input)
+        (#poke SECURITY_ATTRIBUTES, lpSecurityDescriptor) buf (lpSecurityDescriptor input)
+        (#poke SECURITY_ATTRIBUTES, bInheritHandle)       buf (bInheritHandle input)
+    peek buf = do
+        nLength              <- (#peek SECURITY_ATTRIBUTES, nLength)              buf
+        lpSecurityDescriptor <- (#peek SECURITY_ATTRIBUTES, lpSecurityDescriptor) buf
+        bInheritHandle       <- (#peek SECURITY_ATTRIBUTES, bInheritHandle)       buf
+        return SECURITY_ATTRIBUTES{..}
+
+---------------------------------------------------------------------------
+-- API in Haskell
+---------------------------------------------------------------------------
+openEvent :: AccessMode -> Bool -> String -> IO HANDLE
+openEvent amode inherit name = withTString name $ \c_name ->
+    failIf (==nullPtr) "openEvent: OpenEvent" $ c_OpenEvent (fromIntegral amode) inherit c_name
+
+createEvent :: Maybe SECURITY_ATTRIBUTES -> Bool -> Bool -> String -> IO HANDLE
+createEvent msecurity manual initial name = withTString name $ \c_name ->
+    maybeWith with msecurity $ \c_sec ->
+        failIf (==nullPtr) "createEvent: CreateEvent" $ c_CreateEvent c_sec manual initial c_name
+
+duplicateHandle :: HANDLE -> HANDLE -> HANDLE -> AccessMode -> Bool -> DuplicateOption -> IO HANDLE
+duplicateHandle srcProccess srcHandler targetProcess access inherit opts = alloca $ \res -> do
+    failIfFalse_ "duplicateHandle: DuplicateHandle" $ c_DuplicateHandle srcProccess srcHandler targetProcess res (fromIntegral access) inherit opts
+    peek res
+
+setEvent :: HANDLE -> IO ()
+setEvent event = failIfFalse_ "setEvent: SetEvent" $ c_SetEvent event
+
+resetEvent :: HANDLE -> IO ()
+resetEvent event = failIfFalse_ "resetEvent: ResetEvent" $ c_ResetEvent event
+
+pulseEvent :: HANDLE -> IO ()
+pulseEvent event = failIfFalse_ "pulseEvent: PulseEvent" $ c_PulseEvent event
+
+signalObjectAndWait :: HANDLE -> HANDLE -> MilliSeconds -> Bool -> IO WaitResult
+signalObjectAndWait toSignal toWaitOn millis alterable = c_SignalObjectAndWait toSignal toWaitOn millis alterable
+
+waitForSingleObject :: HANDLE -> MilliSeconds -> IO WaitResult
+waitForSingleObject toWaitOn millis = c_WaitForSingleObject toWaitOn millis
+
+waitForSingleObjectEx :: HANDLE -> MilliSeconds -> Bool -> IO WaitResult
+waitForSingleObjectEx toWaitOn millis alterable = c_WaitForSingleObjectEx toWaitOn millis alterable
+
+waitForMultipleObjects :: Vector HANDLE -> Bool -> MilliSeconds -> IO WaitResult
+waitForMultipleObjects v waitAll millis = do
+  let (fvp, n) = V.unsafeToForeignPtr0 v
+  withForeignPtr fvp $ \vp -> c_WaitForMultipleObjects (fromIntegral n) vp waitAll millis
+
+waitForMultipleObjectsEx :: Vector HANDLE -> Bool -> MilliSeconds -> Bool -> IO WaitResult
+waitForMultipleObjectsEx v waitAll millis alterable = do
+  let (fvp, n) = V.unsafeToForeignPtr0 v
+  withForeignPtr fvp $ \vp -> c_WaitForMultipleObjectsEx (fromIntegral n) vp waitAll millis alterable
+
+---------------------------------------------------------------------------
+-- Imports
+---------------------------------------------------------------------------
+foreign import WINDOWS_CCONV "windows.h OpenEventW"
+    c_OpenEvent :: DWORD -> BOOL -> LPCTSTR -> IO HANDLE
+
+foreign import WINDOWS_CCONV "windows.h CreateEventW"
+    c_CreateEvent :: LPSECURITY_ATTRIBUTES -> BOOL -> BOOL -> LPCTSTR -> IO HANDLE
+
+foreign import WINDOWS_CCONV "windows.h DuplicateHandle"
+    c_DuplicateHandle :: HANDLE -> HANDLE -> HANDLE -> Ptr HANDLE -> DWORD -> BOOL -> DWORD -> IO BOOL
+
+foreign import WINDOWS_CCONV "windows.h SetEvent"
+    c_SetEvent :: HANDLE -> IO Bool
+
+foreign import WINDOWS_CCONV "windows.h ResetEvent"
+    c_ResetEvent :: HANDLE -> IO Bool
+
+foreign import WINDOWS_CCONV "windows.h PulseEvent"
+    c_PulseEvent :: HANDLE -> IO Bool
+
+foreign import WINDOWS_CCONV "windows.h SignalObjectAndWait"
+    c_SignalObjectAndWait :: HANDLE -> HANDLE -> DWORD -> BOOL -> IO DWORD
+
+foreign import WINDOWS_CCONV "windows.h WaitForSingleObject"
+    c_WaitForSingleObject :: HANDLE -> DWORD -> IO DWORD
+
+foreign import WINDOWS_CCONV "windows.h WaitForSingleObjectEx"
+    c_WaitForSingleObjectEx :: HANDLE -> DWORD -> BOOL -> IO DWORD
+
+foreign import WINDOWS_CCONV "windows.h WaitForMultipleObjects"
+    c_WaitForMultipleObjects :: DWORD -> Ptr HANDLE -> BOOL -> DWORD -> IO DWORD
+
+foreign import WINDOWS_CCONV "windows.h WaitForMultipleObjectsEx"
+    c_WaitForMultipleObjectsEx :: DWORD -> Ptr HANDLE -> BOOL -> DWORD -> BOOL -> IO DWORD

--- a/System/Win32/File.hsc
+++ b/System/Win32/File.hsc
@@ -239,8 +239,28 @@ newtype GET_FILEEX_INFO_LEVELS = GET_FILEEX_INFO_LEVELS (#type GET_FILEEX_INFO_L
 
 ----------------------------------------------------------------
 
-type LPSECURITY_ATTRIBUTES = Ptr ()
+data SECURITY_ATTRIBUTES = SECURITY_ATTRIBUTES
+    { nLength              :: !DWORD
+    , lpSecurityDescriptor :: !LPVOID
+    , bInheritHandle       :: !BOOL
+    } deriving Show
+
+type PSECURITY_ATTRIBUTES = Ptr SECURITY_ATTRIBUTES
+type LPSECURITY_ATTRIBUTES = Ptr SECURITY_ATTRIBUTES
 type MbLPSECURITY_ATTRIBUTES = Maybe LPSECURITY_ATTRIBUTES
+
+instance Storable SECURITY_ATTRIBUTES where
+    sizeOf = const #{size SECURITY_ATTRIBUTES}
+    alignment _ = #alignment SECURITY_ATTRIBUTES
+    poke buf input = do
+        (#poke SECURITY_ATTRIBUTES, nLength)              buf (nLength input)
+        (#poke SECURITY_ATTRIBUTES, lpSecurityDescriptor) buf (lpSecurityDescriptor input)
+        (#poke SECURITY_ATTRIBUTES, bInheritHandle)       buf (bInheritHandle input)
+    peek buf = do
+        nLength'              <- (#peek SECURITY_ATTRIBUTES, nLength)              buf
+        lpSecurityDescriptor' <- (#peek SECURITY_ATTRIBUTES, lpSecurityDescriptor) buf
+        bInheritHandle'       <- (#peek SECURITY_ATTRIBUTES, bInheritHandle)       buf
+        return $ SECURITY_ATTRIBUTES nLength' lpSecurityDescriptor' bInheritHandle'
 
 ----------------------------------------------------------------
 -- Other types

--- a/Win32.cabal
+++ b/Win32.cabal
@@ -28,7 +28,7 @@ Library
         build-depends: unbuildable<0
         buildable: False
 
-    build-depends:      base >= 4.5 && < 5, bytestring, filepath, vector
+    build-depends:      base >= 4.5 && < 5, bytestring, filepath
     -- Black list hsc2hs 0.68.6 which is horribly broken.
     build-tool-depends: hsc2hs:hsc2hs > 0 && < 0.68.6 || > 0.68.6
     ghc-options:        -Wall -fno-warn-name-shadowing

--- a/Win32.cabal
+++ b/Win32.cabal
@@ -28,7 +28,7 @@ Library
         build-depends: unbuildable<0
         buildable: False
 
-    build-depends:      base >= 4.5 && < 5, bytestring, filepath
+    build-depends:      base >= 4.5 && < 5, bytestring, filepath, vector
     -- Black list hsc2hs 0.68.6 which is horribly broken.
     build-tool-depends: hsc2hs:hsc2hs > 0 && < 0.68.6 || > 0.68.6
     ghc-options:        -Wall -fno-warn-name-shadowing
@@ -69,6 +69,7 @@ Library
         System.Win32
         System.Win32.DebugApi
         System.Win32.DLL
+        System.Win32.Event
         System.Win32.File
         System.Win32.FileMapping
         System.Win32.Info

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,24 @@
 # Changelog for [`Win32` package](http://hackage.haskell.org/package/Win32)
 
+## unreleased
+
+* Add `System.Win32.Event` module
+* Add function `openEvent`
+* Add function `createEvent`
+* Add function `duplicateHandle`
+* Add function `setEvent`
+* Add function `resetEvent`
+* Add function `pulseEvent`
+* Add function `signalObjectAndWait`
+* Add function `waitForSingleObject`
+* Add function `waitForSingleObjectEx`
+* Add function `waitForMultipleObjects`
+* Add function `waitForMultipleObjectsEx`
+* Add enums `DUPLICATE_CLOSE_SOURCE`, `DUPLICATE_SAME_ACCESS`,
+  `EVENT_ALL_ACCESS`, `EVENT_MODIFY_STATE`, `WAIT_ABANDONED`,
+  `WAIT_IO_COMPLETION`, `WAIT_OBJECT_0`, `WAIT_TIMEOUT` and `WAIT_FAILED`.
+* Add struct `SECURITY_ATTRIBUTES`
+
 ## 2.10.0.0 September 2020
 
 * Add function `isWindowVisible`


### PR DESCRIPTION
I needed WinAPI part for system wide events for process communication.

## Description
The PR adds basic bindings for event creation, triggering and waiting/listening on them. Controversial change is that `waitForMultipleObjects` requires `vector` for `Data.Vector.Storable` for handy arrays of `HANDLE`.

## Motivation and Context
The package completely missing bindings for events.

## Types of changes
- Bindings for WinAPI events
- Adding dependency on `vector`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have not added a new Haskell dependency.
- [x] I have included a changelog entry.
- [x] I have not modified the version of the package in `Win32.cabal`.
