### PR TITLE
Remove mapFileBs to eliminate bytestring dependency

### DIFF
--- a/System/Win32/FileMapping.hsc
+++ b/System/Win32/FileMapping.hsc
@@ -1,4 +1,8 @@
+#if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
+#else
+{-# LANGUAGE Trustworthy #-}
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  System.Win32.FileMapping

--- a/System/Win32/FileMapping.hsc
+++ b/System/Win32/FileMapping.hsc
@@ -1,4 +1,4 @@
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  System.Win32.FileMapping
@@ -22,8 +22,6 @@ import System.Win32.File
 import System.Win32.Info
 
 import Control.Exception        ( mask_, bracket )
-import Data.ByteString          ( ByteString )
-import Data.ByteString.Internal ( fromForeignPtr )
 import Foreign                  ( Ptr, nullPtr, plusPtr, maybeWith, FunPtr
                                 , ForeignPtr, newForeignPtr )
 import Foreign.C.Types (CUIntPtr(..))
@@ -52,12 +50,6 @@ mapFile path = do
                     ptr <- mapViewOfFile fm fILE_MAP_READ 0 0
                     newForeignPtr c_UnmapViewOfFileFinaliser ptr
                 return (fp, fromIntegral $ bhfiSize fi)
-
--- | As mapFile, but returns ByteString
-mapFileBs :: FilePath -> IO ByteString
-mapFileBs p = do
-    (fp,i) <- mapFile p
-    return $ fromForeignPtr fp 0 i
 
 data MappedObject = MappedObject HANDLE HANDLE FileMapAccess
 

--- a/Win32.cabal
+++ b/Win32.cabal
@@ -28,7 +28,7 @@ Library
         build-depends: unbuildable<0
         buildable: False
 
-    build-depends:      base >= 4.5 && < 5, bytestring, filepath
+    build-depends:      base >= 4.5 && < 5, filepath
     -- Black list hsc2hs 0.68.6 which is horribly broken.
     build-tool-depends: hsc2hs:hsc2hs > 0 && < 0.68.6 || > 0.68.6
     ghc-options:        -Wall -fno-warn-name-shadowing

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog for [`Win32` package](http://hackage.haskell.org/package/Win32)
 
+## unreleased
+
+* Remove function `mapFileBs`.
+
 ## 2.10.1.0 October 2020
 
 * Add `System.Win32.Event` module


### PR DESCRIPTION
Closes #166.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have not added a new Haskell dependency.
- [x] I have included a changelog entry.
- [x] I have not modified the version of the package in `Win32.cabal`.

I set up GitHub Actions in a separate branch to test my changes: https://github.com/Bodigrim/win32/actions/runs/459405515