### PR TITLE
Re-export base's CodePage from System.Win32.NLS when possible

### DIFF
--- a/System/Win32/NLS.hsc
+++ b/System/Win32/NLS.hsc
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE Trustworthy #-}
 -----------------------------------------------------------------------------
 -- |
@@ -15,6 +16,9 @@
 
 module System.Win32.NLS  (
         module System.Win32.NLS,
+#if MIN_VERSION_base(4,15,0)
+        CodePage,
+#endif
 
         -- defined in System.Win32.Types
         LCID, LANGID, SortID, SubLANGID, PrimaryLANGID,
@@ -33,6 +37,9 @@ import Control.Monad (when)
 import Data.IORef (modifyIORef, newIORef, readIORef)
 import Foreign
 import Foreign.C
+#if MIN_VERSION_base(4,15,0)
+import GHC.IO.Encoding.CodePage (CodePage)
+#endif
 import Text.Printf (printf)
 
 ##include "windows_cconv.h"
@@ -69,7 +76,9 @@ foreign import WINDOWS_CCONV unsafe "windows.h ConvertDefaultLocale"
 
 -- ToDo: various enum functions.
 
+#if !MIN_VERSION_base(4,15,0)
 type CodePage = UINT
+#endif
 
 #{enum CodePage,
  , cP_ACP       = CP_ACP

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog for [`Win32` package](http://hackage.haskell.org/package/Win32)
 
+## next
+* Make `System.Win32.NLS` re-export `CodePage` from `GHC.IO.Encoding.CodePage`
+  in `base` when compiled with `base-4.15` or later.
+
 ## 2.11.0.0 January 2021
 
 * Remove function `mapFileBs`.


### PR DESCRIPTION
## Description
When building with `base-4.15` or later, have `System.Win32.NLS` re-export the `CodePage` type synonym from `GHC.IO.Encoding.CodePage` in `base`.

## Motivation and Context
This avoids potential import clashes, such as the one observed in RyanGlScott/code-page#5. This fixes #169.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] I have not added a new Haskell dependency.
- [X] I have included a changelog entry.
- [X] I have not modified the version of the package in `Win32.cabal`.
