### PR TITLE
Add export lists to all modules

### DIFF
--- a/System/Win32/Automation/Input.hsc
+++ b/System/Win32/Automation/Input.hsc
@@ -11,7 +11,16 @@
    Provide sendInput function and INPUT types.
 -}
 module System.Win32.Automation.Input
-  ( module System.Win32.Automation.Input
+  ( sendInput
+  , sendInputPtr
+  , makeKeyboardInput
+  , PINPUT
+  , LPINPUT
+  , INPUT(..)
+  , PHARDWAREINPUT
+  , HARDWAREINPUT(..)
+  , getMessageExtraInfo
+  , setMessageExtraInfo
   , module System.Win32.Automation.Input.Key
   , module System.Win32.Automation.Input.Mouse
   ) where

--- a/System/Win32/Console/HWND.hs
+++ b/System/Win32/Console/HWND.hs
@@ -9,7 +9,7 @@
 
    Get the handle of the current console window.
 -}
-module System.Win32.Console.HWND where
+module System.Win32.Console.HWND (getConsoleHWND) where
 import Control.Concurrent           ( threadDelay )
 import Control.Exception            ( bracket )
 import Foreign.Ptr                  ( nullPtr )

--- a/System/Win32/Console/Title.hsc
+++ b/System/Win32/Console/Title.hsc
@@ -10,7 +10,10 @@
 
    Get/Set the title for the current console window.
 -}
-module System.Win32.Console.Title where
+module System.Win32.Console.Title
+    ( getConsoleTitle
+    , setConsoleTitle
+    ) where
 
 import System.Win32.String ( LPTSTR, LPCTSTR
                            , withTStringBufferLen, withTString, peekTStringLen )

--- a/System/Win32/DLL.hsc
+++ b/System/Win32/DLL.hsc
@@ -17,7 +17,19 @@
 --
 -----------------------------------------------------------------------------
 
-module System.Win32.DLL where
+module System.Win32.DLL
+    ( disableThreadLibraryCalls
+    , freeLibrary
+    , getModuleFileName
+    , getModuleHandle
+    , getProcAddress
+    , loadLibrary
+    , loadLibraryEx
+    , setDllDirectory
+    , LoadLibraryFlags
+    , lOAD_LIBRARY_AS_DATAFILE
+    , lOAD_WITH_ALTERED_SEARCH_PATH
+    ) where
 
 import System.Win32.Types
 
@@ -41,10 +53,6 @@ freeLibrary hmod =
 foreign import WINDOWS_CCONV unsafe "windows.h FreeLibrary"
   c_FreeLibrary :: HMODULE -> IO Bool
 
-{-# CFILES cbits/HsWin32.c #-}
-foreign import ccall "HsWin32.h &FreeLibraryFinaliser"
-    c_FreeLibraryFinaliser :: FunPtr (HMODULE -> IO ())
-
 getModuleFileName :: HMODULE -> IO String
 getModuleFileName hmod =
   allocaArray 512 $ \ c_str -> do
@@ -64,6 +72,7 @@ getProcAddress :: HMODULE -> String -> IO Addr
 getProcAddress hmod procname =
   withCAString procname $ \ c_procname ->
   failIfNull "GetProcAddress" $ c_GetProcAddress hmod c_procname
+
 foreign import WINDOWS_CCONV unsafe "windows.h GetProcAddress"
   c_GetProcAddress :: HMODULE -> LPCSTR -> IO Addr
 

--- a/System/Win32/DebugApi.hsc
+++ b/System/Win32/DebugApi.hsc
@@ -16,7 +16,59 @@
 -- A collection of FFI declarations for using Windows DebugApi.
 --
 -----------------------------------------------------------------------------
-module System.Win32.DebugApi where
+module System.Win32.DebugApi
+    ( PID, TID, DebugEventId, ForeignAddress
+    , PHANDLE, THANDLE
+    , ThreadInfo
+    , ImageInfo
+    , ExceptionInfo
+    , Exception(..)
+    , DebugEventInfo(..)
+    , DebugEvent
+
+    , debugBreak
+    , isDebuggerPresent
+
+      -- * Debug events
+    , waitForDebugEvent
+    , getDebugEvents
+    , continueDebugEvent
+
+      -- * Debugging another process
+    , debugActiveProcess
+    , peekProcessMemory
+    , readProcessMemory
+    , pokeProcessMemory
+    , withProcessMemory
+    , peekP
+    , pokeP
+
+      -- * Thread control
+    , suspendThread
+    , resumeThread
+    , withSuspendedThread
+
+      -- * Thread register control
+    , getThreadContext
+    , setThreadContext
+    , useAllRegs
+    , withThreadContext
+
+#if __i386__
+    , eax, ebx, ecx, edx, esi, edi, ebp, eip, esp
+#elif __x86_64__
+    , rax, rbx, rcx, rdx, rsi, rdi, rbp, rip, rsp
+#endif
+    , segCs, segDs, segEs, segFs, segGs
+    , eFlags
+    , dr
+    , setReg, getReg, modReg
+    , makeModThreadContext
+    , modifyThreadContext
+
+      -- * Sending debug output to another process
+    , outputDebugString
+    ) where
 
 import Control.Exception( bracket_ )
 import Data.Word        ( Word8, Word32 )

--- a/System/Win32/File.hsc
+++ b/System/Win32/File.hsc
@@ -17,7 +17,226 @@
 --
 -----------------------------------------------------------------------------
 
-module System.Win32.File where
+module System.Win32.File
+    ( -- * Access modes
+      AccessMode
+    , gENERIC_NONE
+    , gENERIC_READ
+    , gENERIC_WRITE
+    , gENERIC_EXECUTE
+    , gENERIC_ALL
+    , dELETE
+    , rEAD_CONTROL
+    , wRITE_DAC
+    , wRITE_OWNER
+    , sYNCHRONIZE
+    , sTANDARD_RIGHTS_REQUIRED
+    , sTANDARD_RIGHTS_READ
+    , sTANDARD_RIGHTS_WRITE
+    , sTANDARD_RIGHTS_EXECUTE
+    , sTANDARD_RIGHTS_ALL
+    , sPECIFIC_RIGHTS_ALL
+    , aCCESS_SYSTEM_SECURITY
+    , mAXIMUM_ALLOWED
+    , fILE_ADD_FILE
+    , fILE_ADD_SUBDIRECTORY
+    , fILE_ALL_ACCESS
+    , fILE_APPEND_DATA
+    , fILE_CREATE_PIPE_INSTANCE
+    , fILE_DELETE_CHILD
+    , fILE_EXECUTE
+    , fILE_LIST_DIRECTORY
+    , fILE_READ_ATTRIBUTES
+    , fILE_READ_DATA
+    , fILE_READ_EA
+    , fILE_TRAVERSE
+    , fILE_WRITE_ATTRIBUTES
+    , fILE_WRITE_DATA
+    , fILE_WRITE_EA
+
+      -- * Sharing modes
+    , ShareMode
+    , fILE_SHARE_NONE
+    , fILE_SHARE_READ
+    , fILE_SHARE_WRITE
+    , fILE_SHARE_DELETE
+
+      -- * Creation modes
+    , CreateMode
+    , cREATE_NEW
+    , cREATE_ALWAYS
+    , oPEN_EXISTING
+    , oPEN_ALWAYS
+    , tRUNCATE_EXISTING
+
+      -- * File attributes and flags
+    , FileAttributeOrFlag
+    , fILE_ATTRIBUTE_READONLY
+    , fILE_ATTRIBUTE_HIDDEN
+    , fILE_ATTRIBUTE_SYSTEM
+    , fILE_ATTRIBUTE_DIRECTORY
+    , fILE_ATTRIBUTE_ARCHIVE
+    , fILE_ATTRIBUTE_NORMAL
+    , fILE_ATTRIBUTE_TEMPORARY
+    , fILE_ATTRIBUTE_COMPRESSED
+    , fILE_ATTRIBUTE_REPARSE_POINT
+    , fILE_FLAG_WRITE_THROUGH
+    , fILE_FLAG_OVERLAPPED
+    , fILE_FLAG_NO_BUFFERING
+    , fILE_FLAG_RANDOM_ACCESS
+    , fILE_FLAG_SEQUENTIAL_SCAN
+    , fILE_FLAG_DELETE_ON_CLOSE
+    , fILE_FLAG_BACKUP_SEMANTICS
+    , fILE_FLAG_POSIX_SEMANTICS
+#ifndef __WINE_WINDOWS_H
+    , sECURITY_ANONYMOUS
+    , sECURITY_IDENTIFICATION
+    , sECURITY_IMPERSONATION
+    , sECURITY_DELEGATION
+    , sECURITY_CONTEXT_TRACKING
+    , sECURITY_EFFECTIVE_ONLY
+    , sECURITY_SQOS_PRESENT
+    , sECURITY_VALID_SQOS_FLAGS
+#endif
+
+      -- * Move file flags
+    , MoveFileFlag
+    , mOVEFILE_REPLACE_EXISTING
+    , mOVEFILE_COPY_ALLOWED
+    , mOVEFILE_DELAY_UNTIL_REBOOT
+
+      -- * File pointer directions
+    , FilePtrDirection
+    , fILE_BEGIN
+    , fILE_CURRENT
+    , fILE_END
+
+      -- * Drive types
+    , DriveType
+    , dRIVE_UNKNOWN
+    , dRIVE_NO_ROOT_DIR
+    , dRIVE_REMOVABLE
+    , dRIVE_FIXED
+    , dRIVE_REMOTE
+    , dRIVE_CDROM
+    , dRIVE_RAMDISK
+
+      -- * Define DOS device flags
+    , DefineDosDeviceFlags
+    , dDD_RAW_TARGET_PATH
+    , dDD_REMOVE_DEFINITION
+    , dDD_EXACT_MATCH_ON_REMOVE
+
+      -- * Binary types
+    , BinaryType
+    , sCS_32BIT_BINARY
+    , sCS_DOS_BINARY
+    , sCS_WOW_BINARY
+    , sCS_PIF_BINARY
+    , sCS_POSIX_BINARY
+    , sCS_OS216_BINARY
+
+      -- * File notification flags
+    , FileNotificationFlag
+    , fILE_NOTIFY_CHANGE_FILE_NAME
+    , fILE_NOTIFY_CHANGE_DIR_NAME
+    , fILE_NOTIFY_CHANGE_ATTRIBUTES
+    , fILE_NOTIFY_CHANGE_SIZE
+    , fILE_NOTIFY_CHANGE_LAST_WRITE
+    , fILE_NOTIFY_CHANGE_SECURITY
+
+      -- * File types
+    , FileType
+    , fILE_TYPE_UNKNOWN
+    , fILE_TYPE_DISK
+    , fILE_TYPE_CHAR
+    , fILE_TYPE_PIPE
+    , fILE_TYPE_REMOTE
+
+      -- * Lock modes
+    , LockMode
+    , lOCKFILE_EXCLUSIVE_LOCK
+    , lOCKFILE_FAIL_IMMEDIATELY
+
+      -- * GetFileEx information levels
+    , GET_FILEEX_INFO_LEVELS
+    , getFileExInfoStandard
+    , getFileExMaxInfoLevel
+
+      -- * Security attributes
+    , SECURITY_ATTRIBUTES(..)
+    , PSECURITY_ATTRIBUTES
+    , LPSECURITY_ATTRIBUTES
+    , MbLPSECURITY_ATTRIBUTES
+
+      -- * BY_HANDLE file information
+    , BY_HANDLE_FILE_INFORMATION(..)
+
+      -- * Win32 file attribute data
+    , WIN32_FILE_ATTRIBUTE_DATA(..)
+
+      -- * Helpers
+    , failIfWithRetry
+    , failIfWithRetry_
+    , failIfFalseWithRetry_
+      -- * File operations
+    , deleteFile
+    , copyFile
+    , moveFile
+    , moveFileEx
+    , setCurrentDirectory
+    , createDirectory
+    , createDirectoryEx
+    , removeDirectory
+    , getBinaryType
+
+      -- * HANDLE operations
+    , createFile
+    , closeHandle
+    , getFileType
+    , flushFileBuffers
+    , setEndOfFile
+    , setFileAttributes
+    , getFileAttributes
+    , getFileAttributesExStandard
+    , getFileInformationByHandle
+
+      -- ** Reading/writing
+      -- | Some operations below bear the @win32_@ prefix to avoid shadowing
+      -- operations from "Prelude".
+    , OVERLAPPED(..)
+    , LPOVERLAPPED
+    , MbLPOVERLAPPED
+    , win32_ReadFile
+    , win32_WriteFile
+    , setFilePointerEx
+
+      -- * File notifications
+    , findFirstChangeNotification
+    , findNextChangeNotification
+    , findCloseChangeNotification
+
+      -- * Directories
+    , FindData
+    , getFindDataFileName
+    , findFirstFile
+    , findNextFile
+    , findClose
+
+      -- * DOS device flags
+    , defineDosDevice
+    , areFileApisANSI
+    , setFileApisToOEM
+    , setFileApisToANSI
+    , setHandleCount
+    , getLogicalDrives
+    , getDiskFreeSpace
+    , setVolumeLabel
+
+      -- * File locks
+    , lockFile
+    , unlockFile
+    ) where
 
 import System.Win32.Types
 import System.Win32.Time

--- a/System/Win32/FileMapping.hsc
+++ b/System/Win32/FileMapping.hsc
@@ -16,7 +16,33 @@
 -- A collection of FFI declarations for interfacing with Win32 mapped files.
 --
 -----------------------------------------------------------------------------
-module System.Win32.FileMapping where
+module System.Win32.FileMapping
+    ( mapFile
+    , MappedObject(..)
+    , withMappedFile
+    , withMappedArea
+      -- * Enums
+      -- ** Section protection flags
+    , ProtectSectionFlags
+    , sEC_COMMIT
+    , sEC_IMAGE
+    , sEC_NOCACHE
+    , sEC_RESERVE
+      -- ** Access falgs
+    , FileMapAccess
+    , fILE_MAP_ALL_ACCESS
+    , fILE_MAP_COPY
+    , fILE_MAP_READ
+    , fILE_MAP_WRITE
+    , fILE_SHARE_WRITE
+
+      -- * Mapping files
+    , createFileMapping
+    , openFileMapping
+    , mapViewOfFileEx
+    , mapViewOfFile
+    , unmapViewOfFile
+    ) where
 
 import System.Win32.Types   ( HANDLE, DWORD, BOOL, SIZE_T, LPCTSTR, withTString
                             , failIf, failIfNull, DDWORD, ddwordToDwords

--- a/System/Win32/HardLink.hs
+++ b/System/Win32/HardLink.hs
@@ -17,8 +17,10 @@
      * ReFS doesn't support hard link currently.
 -}
 module System.Win32.HardLink
-  ( module System.Win32.HardLink
+  ( createHardLink
+  , createHardLink'
   ) where
+
 import System.Win32.File   ( LPSECURITY_ATTRIBUTES, failIfFalseWithRetry_ )
 import System.Win32.String ( LPCTSTR, withTString )
 import System.Win32.Types  ( BOOL, nullPtr )

--- a/System/Win32/Info.hsc
+++ b/System/Win32/Info.hsc
@@ -17,7 +17,117 @@
 --
 -----------------------------------------------------------------------------
 
-module System.Win32.Info where
+module System.Win32.Info
+    ( SystemColor
+    , cOLOR_SCROLLBAR
+    , cOLOR_BACKGROUND
+    , cOLOR_ACTIVECAPTION
+    , cOLOR_INACTIVECAPTION
+    , cOLOR_MENU
+    , cOLOR_WINDOW
+    , cOLOR_WINDOWFRAME
+    , cOLOR_MENUTEXT
+    , cOLOR_WINDOWTEXT
+    , cOLOR_CAPTIONTEXT
+    , cOLOR_ACTIVEBORDER
+    , cOLOR_INACTIVEBORDER
+    , cOLOR_APPWORKSPACE
+    , cOLOR_HIGHLIGHT
+    , cOLOR_HIGHLIGHTTEXT
+    , cOLOR_BTNFACE
+    , cOLOR_BTNSHADOW
+    , cOLOR_GRAYTEXT
+    , cOLOR_BTNTEXT
+    , cOLOR_INACTIVECAPTIONTEXT
+    , cOLOR_BTNHIGHLIGHT
+
+      -- * Standard directories
+    , getSystemDirectory
+    , getWindowsDirectory
+    , getCurrentDirectory
+    , getTemporaryDirectory
+    , getFullPathName
+    , getLongPathName
+    , getShortPathName
+    , searchPath
+
+      -- * System information
+    , ProcessorArchitecture(..)
+    , SYSTEM_INFO(..)
+    , getSystemInfo
+
+      -- * System metrics
+    , SMSetting
+    , sM_ARRANGE
+    , sM_CLEANBOOT
+    , sM_CMETRICS
+    , sM_CMOUSEBUTTONS
+    , sM_CXBORDER
+    , sM_CYBORDER
+    , sM_CXCURSOR
+    , sM_CYCURSOR
+    , sM_CXDLGFRAME
+    , sM_CYDLGFRAME
+    , sM_CXDOUBLECLK
+    , sM_CYDOUBLECLK
+    , sM_CXDRAG
+    , sM_CYDRAG
+    , sM_CXEDGE
+    , sM_CYEDGE
+    , sM_CXFRAME
+    , sM_CYFRAME
+    , sM_CXFULLSCREEN
+    , sM_CYFULLSCREEN
+    , sM_CXHSCROLL
+    , sM_CYVSCROLL
+    , sM_CXICON
+    , sM_CYICON
+    , sM_CXICONSPACING
+    , sM_CYICONSPACING
+    , sM_CXMAXIMIZED
+    , sM_CYMAXIMIZED
+    , sM_CXMENUCHECK
+    , sM_CYMENUCHECK
+    , sM_CXMENUSIZE
+    , sM_CYMENUSIZE
+    , sM_CXMIN
+    , sM_CYMIN
+    , sM_CXMINIMIZED
+    , sM_CYMINIMIZED
+    , sM_CXMINTRACK
+    , sM_CYMINTRACK
+    , sM_CXSCREEN
+    , sM_CYSCREEN
+    , sM_CXSIZE
+    , sM_CYSIZE
+    , sM_CXSIZEFRAME
+    , sM_CYSIZEFRAME
+    , sM_CXSMICON
+    , sM_CYSMICON
+    , sM_CXSMSIZE
+    , sM_CYSMSIZE
+    , sM_CXVSCROLL
+    , sM_CYHSCROLL
+    , sM_CYVTHUMB
+    , sM_CYCAPTION
+    , sM_CYKANJIWINDOW
+    , sM_CYMENU
+    , sM_CYSMCAPTION
+    , sM_DBCSENABLED
+    , sM_DEBUG
+    , sM_MENUDROPALIGNMENT
+    , sM_MIDEASTENABLED
+    , sM_MOUSEPRESENT
+    , sM_NETWORK
+    , sM_PENWINDOWS
+    , sM_SECURE
+    , sM_SHOWSOUNDS
+    , sM_SLOWMACHINE
+    , sM_SWAPBUTTON
+
+      -- * User name
+    , getUserName
+    ) where
 
 import Control.Exception (catch)
 import Foreign.Marshal.Alloc (alloca)
@@ -111,6 +221,7 @@ getWindowsDirectory = try "GetWindowsDirectory" c_getWindowsDirectory 512
 
 getCurrentDirectory :: IO String
 getCurrentDirectory = try "GetCurrentDirectory" (flip c_getCurrentDirectory) 512
+
 getTemporaryDirectory :: IO String
 getTemporaryDirectory = try "GetTempPath" (flip c_getTempPath) 512
 

--- a/System/Win32/Info/Version.hsc
+++ b/System/Win32/Info/Version.hsc
@@ -19,6 +19,7 @@ module System.Win32.Info.Version
     -- * Verify OS version
   , isVistaOrLater, is7OrLater
   ) where
+
 import Foreign.Ptr           ( Ptr, plusPtr )
 import Foreign.Marshal.Alloc ( alloca )
 import Foreign.Storable      ( Storable(..) )

--- a/System/Win32/Mem.hsc
+++ b/System/Win32/Mem.hsc
@@ -17,7 +17,90 @@
 --
 -----------------------------------------------------------------------------
 
-module System.Win32.Mem where
+module System.Win32.Mem
+    ( MEMORY_BASIC_INFORMATION(..)
+    , copyMemory
+    , moveMemory
+    , fillMemory
+    , zeroMemory
+    , memset
+    , getProcessHeap
+#ifndef __WINE_WINDOWS_H
+    , getProcessHeaps
+#endif
+    , HGLOBAL
+      -- * Global allocation
+    , GlobalAllocFlags
+    , gMEM_INVALID_HANDLE
+    , gMEM_FIXED
+    , gMEM_MOVEABLE
+    , gPTR
+    , gHND
+    , gMEM_DDESHARE
+    , gMEM_SHARE
+    , gMEM_LOWER
+    , gMEM_NOCOMPACT
+    , gMEM_NODISCARD
+    , gMEM_NOT_BANKED
+    , gMEM_NOTIFY
+    , gMEM_ZEROINIT
+    , globalAlloc
+    , globalFlags
+    , globalFree
+    , globalHandle
+    , globalLock
+    , globalReAlloc
+    , globalSize
+    , globalUnlock
+
+      -- * Heap allocation
+    , HeapAllocFlags
+    , hEAP_GENERATE_EXCEPTIONS
+    , hEAP_NO_SERIALIZE
+    , hEAP_ZERO_MEMORY
+    , heapAlloc
+    , heapCompact
+    , heapCreate
+    , heapDestroy
+    , heapFree
+    , heapLock
+    , heapReAlloc
+    , heapSize
+    , heapUnlock
+    , heapValidate
+
+      -- * Virtual allocation
+      -- ** Allocation
+    , virtualAlloc
+    , virtualAllocEx
+    , VirtualAllocFlags
+    , mEM_COMMIT
+    , mEM_RESERVE
+      -- ** Locking
+    , virtualLock
+    , virtualUnlock
+      -- ** Protection
+    , virtualProtect
+    , virtualProtectEx
+    , virtualQueryEx
+    , ProtectFlags
+    , pAGE_READONLY
+    , pAGE_READWRITE
+    , pAGE_EXECUTE
+    , pAGE_EXECUTE_READ
+    , pAGE_EXECUTE_READWRITE
+    , pAGE_GUARD
+    , pAGE_NOACCESS
+    , pAGE_NOCACHE
+      -- ** Freeing
+    , virtualFree
+    , virtualFreeEx
+    , FreeFlags
+    , mEM_DECOMMIT
+    , mEM_RELEASE
+
+
+    ) where
 
 import System.Win32.Types
 

--- a/System/Win32/Process.hsc
+++ b/System/Win32/Process.hsc
@@ -17,7 +17,49 @@
 --
 -----------------------------------------------------------------------------
 
-module System.Win32.Process where
+module System.Win32.Process
+    ( -- * Sleeping
+      iNFINITE
+    , sleep
+      -- * Processes pperations
+    , ProcessId
+    , ProcessHandle
+    , ProcessAccessRights
+    , pROCESS_ALL_ACCESS
+    , pROCESS_CREATE_PROCESS
+    , pROCESS_CREATE_THREAD
+    , pROCESS_DUP_HANDLE
+    , pROCESS_QUERY_INFORMATION
+    , pROCESS_SET_QUOTA
+    , pROCESS_SET_INFORMATION
+    , pROCESS_TERMINATE
+    , pROCESS_VM_OPERATION
+    , pROCESS_VM_READ
+    , pROCESS_VM_WRITE
+    , openProcess
+    , getProcessId
+    , getCurrentProcessId
+    , getCurrentProcess
+      -- * Terminating
+    , terminateProcessById
+      -- * Toolhelp32
+    , Th32SnapHandle
+    , Th32SnapFlags
+    , tH32CS_SNAPALL
+    , tH32CS_SNAPHEAPLIST
+    , tH32CS_SNAPMODULE
+    , tH32CS_SNAPMODULE32
+    , tH32CS_SNAPMODULE64
+    , tH32CS_SNAPPROCESS
+    , tH32CS_SNAPTHREAD
+    , ProcessEntry32
+    , ModuleEntry32
+    , createToolhelp32Snapshot
+    , withTh32Snap
+    , th32SnapEnumProcesses
+    , th32SnapEnumModules
+    ) where
+
 import Control.Exception     ( bracket )
 import Control.Monad         ( liftM5 )
 import Foreign               ( Ptr, peekByteOff, allocaBytes, pokeByteOff

--- a/System/Win32/Registry.hsc
+++ b/System/Win32/Registry.hsc
@@ -14,43 +14,102 @@
 -----------------------------------------------------------------------------
 
 module System.Win32.Registry
-                ( module System.Win32.Registry
-                ) where
-{- What's really on offer:
-        (
-          regCloseKey        -- :: HKEY -> IO ()
-        , regConnectRegistry -- :: Maybe String -> HKEY -> IO HKEY
-        , regCreateKey       -- :: HKEY -> String -> IO HKEY
-        , regCreateKeyEx     -- :: HKEY -> String -> Maybe String
-                             -- -> RegCreateOptions -> REGSAM
-                             -- -> Maybe LPSECURITY_ATTRIBUTES
-                             -- -> IO (HKEY, Bool)
-        , regDeleteKey       -- :: HKEY -> String -> IO ()
-        , regDeleteValue     -- :: HKEY -> String -> IO ()
-        , regEnumKeys        -- :: HKEY -> IO [String]
-        , regEnumKey         -- :: HKEY -> DWORD -> Addr -> DWORD -> IO String
-        , regEnumKeyValue    -- :: HKEY -> DWORD -> Addr -> DWORD -> Addr -> DWORD -> IO String
-        , regFlushKey        -- :: HKEY -> IO ()
-        , regLoadKey         -- :: HKEY -> String -> String -> IO ()
-        , regNotifyChangeKeyValue -- :: HKEY -> Bool -> RegNotifyOptions
-                                  -- -> HANDLE -> Bool -> IO ()
-        , regOpenKey         -- :: HKEY -> String -> IO HKEY
-        , regOpenKeyEx       -- :: HKEY -> String -> REGSAM -> IO HKEY
-        , regQueryInfoKey    -- :: HKEY -> IO RegInfoKey
-        , regQueryValue      -- :: HKEY -> Maybe String -> IO String
-        , regQueryDefaultValue -- :: HKEY -> String -> IO String
-        , regQueryValueEx    -- :: HKEY -> String -> Addr -> Int -> IO RegValueType
-        , regReplaceKey      -- :: HKEY -> Maybe String -> String -> String -> IO ()
-        , regRestoreKey      -- :: HKEY -> String -> RegRestoreFlags -> IO ()
-        , regSaveKey         -- :: HKEY -> String -> Maybe LPSECURITY_ATTRIBUTES -> IO ()
-        , regGetValue        -- :: HKEY -> Maybe String -> Maybe String -> RegTypeRestriction
-                             -- -> Maybe LPDWORD -> Maybe LPVOID -> Maybe LPDWORD -> IO ()
-        , regSetValue        -- :: HKEY -> String -> String -> IO ()
-        , regSetValueEx      -- :: HKEY -> String -> RegValueType -> LPTSTR -> Int -> IO ()
-        , regSetStringValue  -- :: HKEY -> String -> String -> IO ()
-        , regUnloadKey       -- :: HKEY -> String -> IO ()
-        ) where
--}
+    (
+      -- * HKEY
+      HKEY
+    , hKEY_CLASSES_ROOT
+    , hKEY_CURRENT_CONFIG
+    , hKEY_CURRENT_USER
+    , hKEY_LOCAL_MACHINE
+    , hKEY_USERS
+
+      -- * Creation options
+    , RegCreateOptions
+    , rEG_OPTION_NON_VOLATILE
+    , rEG_OPTION_VOLATILE
+
+      -- * REGSAM
+    , REGSAM
+    , kEY_ALL_ACCESS
+    , kEY_CREATE_LINK
+    , kEY_CREATE_SUB_KEY
+    , kEY_ENUMERATE_SUB_KEYS
+    , kEY_EXECUTE
+    , kEY_NOTIFY
+    , kEY_QUERY_VALUE
+    , kEY_READ
+    , kEY_SET_VALUE
+    , kEY_WRITE
+
+      -- * Registry operations
+    , regCloseKey
+    , regConnectRegistry
+    , regCreateKey
+    , regCreateKeyEx
+    , regDeleteKey
+    , regDeleteValue
+    , regEnumKeys
+    , regEnumKeyVals
+    , regEnumKey
+    , regEnumValue
+    , regFlushKey
+    , regLoadKey
+    , regUnLoadKey
+    , regNotifyChangeKeyValue
+    , RegNotifyOptions
+    , rEG_NOTIFY_CHANGE_NAME
+    , rEG_NOTIFY_CHANGE_ATTRIBUTES
+    , rEG_NOTIFY_CHANGE_LAST_SET
+    , rEG_NOTIFY_CHANGE_SECURITY
+
+    , regOpenKey
+    , regOpenKeyEx
+    , regQueryInfoKey
+    , RegInfoKey(..)
+    , regQueryValue
+    , regQueryValueKey
+    , regQueryDefaultValue
+    , regQueryValueEx
+    , regReplaceKey
+    , RegRestoreFlags
+    , rEG_WHOLE_HIVE_VOLATILE
+    , rEG_REFRESH_HIVE
+    , rEG_NO_LAZY_FLUSH
+    , regRestoreKey
+    , regSaveKey
+    , regGetValue
+    , RegTypeRestriction
+    , rRF_RT_ANY
+    , rRF_RT_DWORD
+    , rRF_RT_QWORD
+    , rRF_RT_REG_BINARY
+    , rRF_RT_REG_DWORD
+    , rRF_RT_REG_EXPAND_SZ
+    , rRF_RT_REG_MULTI_SZ
+    , rRF_RT_REG_NONE
+    , rRF_RT_REG_QWORD
+    , rRF_RT_REG_SZ
+    , rRF_NOEXPAND
+    , rRF_ZEROONFAILURE
+    , rRF_SUBKEY_WOW6464KEY
+    , rRF_SUBKEY_WOW6432KEY
+
+    , regSetValue
+    , regSetValueEx
+    , RegValueType
+    , rEG_BINARY
+    , rEG_DWORD
+    , rEG_DWORD_LITTLE_ENDIAN
+    , rEG_DWORD_BIG_ENDIAN
+    , rEG_EXPAND_SZ
+    , rEG_LINK
+    , rEG_MULTI_SZ
+    , rEG_NONE
+    , rEG_RESOURCE_LIST
+    , rEG_SZ
+
+    , regSetStringValue  -- :: HKEY -> String -> String -> IO ()
+    ) where
 
 {-
  Registry API omissions:

--- a/System/Win32/SymbolicLink.hsc
+++ b/System/Win32/SymbolicLink.hsc
@@ -25,7 +25,14 @@
    addition to the target and link name to enable this behavior.
 -}
 module System.Win32.SymbolicLink
-  ( module System.Win32.SymbolicLink
+  ( SymbolicLinkFlags
+  , sYMBOLIC_LINK_FLAG_FILE
+  , sYMBOLIC_LINK_FLAG_DIRECTORY
+  , sYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE
+  , createSymbolicLink
+  , createSymbolicLink'
+  , createSymbolicLinkFile
+  , createSymbolicLinkDirectory
   ) where
 
 import Data.Bits ((.|.))

--- a/System/Win32/Thread.hs
+++ b/System/Win32/Thread.hs
@@ -15,14 +15,10 @@ module System.Win32.Thread
   ( THANDLE, TID
   , getCurrentThread
   , suspendThread
-  , c_SuspendThread
   , resumeThread
-  , c_ResumeThread
   , withSuspendedThread
   , getThreadId
-  , c_GetThreadId
   , getCurrentThreadId
-  , c_GetCurrentThreadId
   ) where
 
 import System.Win32.DebugApi

--- a/System/Win32/Time.hsc
+++ b/System/Win32/Time.hsc
@@ -16,7 +16,40 @@
 -- A collection of FFI declarations for interfacing with Win32 Time API.
 --
 -----------------------------------------------------------------------------
-module System.Win32.Time where
+module System.Win32.Time
+    ( FILETIME(..)
+    , SYSTEMTIME(..)
+    , TIME_ZONE_INFORMATION(..)
+    , TimeZoneId(..)
+    , getSystemTime
+    , setSystemTime
+    , getSystemTimeAsFileTime
+    , getLocalTime
+    , setLocalTime
+    , getSystemTimeAdjustment
+    , getTickCount
+    , getLastInputInfo
+    , getIdleTime
+    , setSystemTimeAdjustment
+    , getTimeZoneInformation
+    , systemTimeToFileTime
+    , fileTimeToSystemTime
+    , getFileTime
+    , setFileTime
+    , fileTimeToLocalFileTime
+    , localFileTimeToFileTime
+    , queryPerformanceFrequency
+    , queryPerformanceCounter
+    , GetTimeFormatFlags
+    , lOCALE_NOUSEROVERRIDE
+    , lOCALE_USE_CP_ACP
+    , tIME_NOMINUTESORSECONDS
+    , tIME_NOSECONDS
+    , tIME_NOTIMEMARKER
+    , tIME_FORCE24HOURFORMAT
+    , getTimeFormatEx
+    , getTimeFormat
+    ) where
 
 import System.Win32.String  ( peekTStringLen, withTString )
 import System.Win32.Types   ( BOOL, DDWORD, DWORD, HANDLE, LARGE_INTEGER, LCID

--- a/Win32.cabal
+++ b/Win32.cabal
@@ -1,5 +1,5 @@
 name:           Win32
-version:        2.11.1.0
+version:        2.12.0.0
 license:        BSD3
 license-file:   LICENSE
 author:         Alastair Reid, shelarcy, Tamar Christina

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,14 @@
 # Changelog for [`Win32` package](http://hackage.haskell.org/package/Win32)
 
-## 2.11.1.0 February 2021
+## 2.12.0.0 March 2021
 
 * Win32 for GHC 9.2.x
+* Add export lists to all modules, hiding numerous internal `c_` bindings.
+* Update the type of `setFileTime` to reflect the fact that the `FILETIME`
+  arguments are in fact `Maybe`s.
+
+## 2.11.1.0 February 2021
+
 * Make `System.Win32.NLS` re-export `CodePage` from `GHC.IO.Encoding.CodePage`
   in `base` when compiled with `base-4.15` or later.
 


### PR DESCRIPTION

## Description
This prevents the foreign C bindings from being exposed to clients.

## Motivation and Context
Previously the internal `c_*` bindings leaked from many modules. Fixes #174.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have not added a new Haskell dependency.
- [ ] I have included a changelog entry.
- [ ] I have not modified the version of the package in `Win32.cabal`.
