### PR TITLE
Enable -Werror to match internal CI

### DIFF
--- a/System/Win32/File.hsc
+++ b/System/Win32/File.hsc
@@ -687,10 +687,6 @@ closeHandle h =
 foreign import WINDOWS_CCONV unsafe "windows.h CloseHandle"
   c_CloseHandle :: HANDLE -> IO Bool
 
-{-# CFILES cbits/HsWin32.c #-}
-foreign import ccall "HsWin32.h &CloseHandleFinaliser"
-    c_CloseHandleFinaliser :: FunPtr (Ptr a -> IO ())
-
 foreign import WINDOWS_CCONV unsafe "windows.h GetFileType"
   getFileType :: HANDLE -> IO FileType
 --Apparently no error code

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,18 +71,18 @@ install:
 before_build:
  - cabal --version
  - ghc --version
- - cabal %CABOPTS% new-update
+ - cabal %CABOPTS% update
  - IF EXIST configure.ac bash -c "autoreconf -i"
  - rmdir /Q /S dist-newstyle
 
 build_script:
  - echo packages:. > cabal.project
- - cabal %CABOPTS% build -j all
+ - cabal %CABOPTS% build -j all --ghc-options="-Werror"
  # Build from sdist if required.
  - ps: >-
     If ($env:PKG_TEST -Match "yes") {
        cabal sdist
        echo "packages: dist-newstyle/sdist/*.tar.gz" | Out-File -Encoding ASCII cabal.project
        cat cabal.project
-       cabal $env:CABOPTS build -j pkg:Win32
+       cabal $env:CABOPTS build -j pkg:Win32 --ghc-options="-Werror"
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Enable Werror in build so internal and external CI match

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have not added a new Haskell dependency.
- [ ] I have included a changelog entry.
- [ ] I have not modified the version of the package in `Win32.cabal`.
