### PR TITLE
add all flags for CreateToolhelp32Snapshot

### DIFF
--- a/include/tlhelp32_compat.h
+++ b/include/tlhelp32_compat.h
@@ -6,10 +6,21 @@
  */
 #if __GLASGOW_HASKELL__ > 708
 #else
-// Some declarations from tlhelp32.h that we need in Win32
+// Declarations from tlhelp32.h that Win32 requires
 #include <windows.h>
 
+// CreateToolhelp32Snapshot Flags
+// https://docs.microsoft.com/en-us/windows/win32/api/tlhelp32/nf-tlhelp32-createtoolhelp32snapshot
+
+#define TH32CS_INHERIT      0x80000000
+
+#define TH32CS_SNAPHEAPLIST 0x00000001
+#define TH32CS_SNAPPROCESS  0x00000002
+#define TH32CS_SNAPTHREAD   0x00000004
+#define TH32CS_SNAPMODULE   0x00000008
 #define TH32CS_SNAPMODULE32 0x00000010
+
+#define TH32CS_SNAPALL (TH32CS_SNAPHEAPLIST|TH32CS_SNAPPROCESS|TH32CS_SNAPTHREAD|TH32CS_SNAPMODULE)
 
 #endif
 #endif /* TLHELP32_COMPAT_H */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A commit https://github.com/haskell/win32/commit/bc5d6005fb0516aab1009adccb252a1454a5ba69 adding a compatibility header for tlhelp32.h, did not include all the flags for CreateToolhelp32Snapshot. 
## Description
<!--- Describe your changes in detail -->
The intent is to add the remaining flags used by [CreateToolhelp32Snapshot](https://docs.microsoft.com/en-us/windows/win32/api/tlhelp32/nf-tlhelp32-createtoolhelp32snapshot).
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The addition of the rest of the flags used in the library, would prevent errors on older GHC versions.
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have not added a new Haskell dependency.
- [ ] I have included a changelog entry.
- [x] I have not modified the version of the package in `Win32.cabal`.
