### PR TITLE
Make cygwinMSYSCheck more robust (#186)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog for [`Win32` package](http://hackage.haskell.org/package/Win32)
 
+## next
+
+* Fix a bug in which `System.Win32.MinTTY.isMinTTY` would incorrectly return
+  `False` on recent versions of MinTTY.
+
 ## 2.13.0.0 August 2021
 
 * Fix type of c_SetWindowLongPtr. See #180


### PR DESCRIPTION
We cannot rely on `"-master`" being at the end of the filepath name in `cygwinMSYSCheck` on recent MinTTYs.

## Description
To accommodate, this patch updates the implementation of `cygwinMSYSCheck` to match what `git-for-windows` does:

* Always use `isInfixOf` to check if `"cygwin-"`, `"msys-"`, and "`-pty"` are in the filepath name.
* Don't check `"-master"` at all, as this seems to assume a naming convention that could change in the future.

## Motivation and Context

Fixes #186.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have not added a new Haskell dependency.
- [x] I have included a changelog entry.
- [x] I have not modified the version of the package in `Win32.cabal`.
