### PR TITLE
Add support for duplex and console handles to withHandleToHANDLE with winio

### DIFF
--- a/Win32.cabal
+++ b/Win32.cabal
@@ -1,5 +1,5 @@
 name:           Win32
-version:        2.13.1.0
+version:        2.13.2.0
 license:        BSD3
 license-file:   LICENSE
 author:         Alastair Reid, shelarcy, Tamar Christina
@@ -11,7 +11,7 @@ category:       System, Graphics
 synopsis:       A binding to Windows Win32 API.
 description:    This library contains direct bindings to the Windows Win32 APIs for Haskell.
 build-type:     Simple
-cabal-version:  >= 2.0
+cabal-version:  2.0
 extra-source-files:
     include/diatemp.h include/dumpBMP.h include/ellipse.h include/errors.h
     include/Win32Aux.h include/win32debug.h include/alignment.h

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## New - Unreleased
 
 * Set maximum string size for getComputerName. (See #190)
+* Update withHandleToHANDLENative to handle duplex and console handles (See #191)
 
 ## 2.13.1.0 November 2021
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Handled `Duplex` and `Console` handles in `withHandleToHANDLE` with WINIO the
same way they are handled with the POSIX interface.

Fixes #191 and addresses https://github.com/UnkindPartition/ansi-terminal/issues/114

## Description

Win32 acts as an intermediate translation layer between projects so they don't have
to be really aware of which I/O manager is running at any given time.

The `withHandleToHANDLE` is an I/O manager agnostic way to retrieve native handles
but the behavior of `withHandleToHANDLEPosix` was different from `withHandleToHANDLENative`.

This normalizes them.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have not added a new Haskell dependency.
- [x] I have included a changelog entry.
- [x] I have not modified the version of the package in `Win32.cabal`.
