### PR TITLE
add createFile_NoRetry

### DIFF
--- a/System/Win32/File.hsc
+++ b/System/Win32/File.hsc
@@ -256,7 +256,7 @@ import Control.Concurrent
 
 -- | like failIf, but retried on sharing violations.
 -- This is necessary for many file operations; see
---   http://support.microsoft.com/kb/316609
+--   https://www.betaarchive.com/wiki/index.php/Microsoft_KB_Archive/316609
 --
 failIfWithRetry :: (a -> Bool) -> String -> IO a -> IO a
 failIfWithRetry cond msg action = retryOrFail retries

--- a/System/Win32/File.hsc
+++ b/System/Win32/File.hsc
@@ -254,7 +254,7 @@ import Control.Concurrent
 -- File operations
 ----------------------------------------------------------------
 
--- | like failIfFalse_, but retried on sharing violations.
+-- | like failIf, but retried on sharing violations.
 -- This is necessary for many file operations; see
 --   http://support.microsoft.com/kb/316609
 --

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog for [`Win32` package](http://hackage.haskell.org/package/Win32)
 
+## 2.13.3.1
+
+* Add function `createFile_NoRetry` (see #208)
+
 ## 2.13.3.0 July 2022
 
 * Add AFPP support (see #198)


### PR DESCRIPTION
## Description

Adds a version of createFile that does not retry. 

## Motivation and Context

This used to be possible using `c_createFile` which was exported somewhat unintentionally before.

Fixes https://github.com/haskell/win32/issues/208

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have not added a new Haskell dependency.
- [x] I have included a changelog entry.
- [x] I have not modified the version of the package in `Win32.cabal`.
