### PR TITLE
Docs: Clarify that `isMinTTY` only checks for old MinTTYs

### DIFF
--- a/System/Win32/MinTTY.hsc
+++ b/System/Win32/MinTTY.hsc
@@ -15,7 +15,12 @@
 -- Stability   :  provisional
 -- Portability :  portable
 --
--- A function to check if the current terminal uses MinTTY.
+-- A function to check if the current terminal uses an old version of MinTTY
+-- that emulates a TTY. Note, however, that this does not check for more recent
+-- versions of MinTTY that use the native Windows console PTY directly. The old
+-- approach (where MinTTY emulates a TTY) sometimes requires different
+-- approaches to handling keyboard inputs.
+--
 -- Much of this code was originally authored by Phil Ruffwind and the
 -- git-for-windows project.
 --
@@ -50,8 +55,9 @@ import Foreign.C.Types
 #include <windows.h>
 #include "winternl_compat.h"
 
--- | Returns 'True' if the current process's standard error is attached to a
--- MinTTY console (e.g., Cygwin or MSYS). Returns 'False' otherwise.
+-- | Returns 'True' if the current process's standard error is attached to an
+-- emulated MinTTY console (e.g., Cygwin or MSYS that use an old version of
+-- MinTTY). Returns 'False' otherwise.
 isMinTTY :: IO Bool
 isMinTTY = do
     h <- getStdHandle sTD_ERROR_HANDLE
@@ -61,8 +67,9 @@ isMinTTY = do
        then return False
        else isMinTTYHandle h
 
--- | Returns 'True' is the given handle is attached to a MinTTY console
--- (e.g., Cygwin or MSYS). Returns 'False' otherwise.
+-- | Returns 'True' is the given handle is attached to an emulated MinTTY
+-- console (e.g., Cygwin or MSYS that use an old version of MinTTY). Returns
+-- 'False' otherwise.
 isMinTTYHandle :: HANDLE -> IO Bool
 isMinTTYHandle h = do
     fileType <- getFileType h


### PR DESCRIPTION
Despite the name, `isMinTTY` is only capable of detecting the presence of old versions of MinTTY. The name of the function is perhaps misleading in that regard, but it is widely used enough at this point to where renaming it would be disruptive. Instead, let's just clarify its intent in the documentation.

<!--- Provide a general summary of your changes in the Title above -->

## Description
This alters the Haddocks in `System.Win32.MinTTY` to clarify to which versions of MinTTY the `isMinTTY` and `isMinTTYHandle` functions apply.

## Motivation and Context
Resolves #216.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have not added a new Haskell dependency.
- [ ] I have included a changelog entry.
- [ ] I have not modified the version of the package in `Win32.cabal`.
