### PR TITLE
Fix #224

### DIFF
--- a/System/Win32/WindowsString/Console.hsc
+++ b/System/Win32/WindowsString/Console.hsc
@@ -63,14 +63,9 @@ import System.Win32.WindowsString.Types
 import System.Win32.Console.Internal
 import System.Win32.Console hiding (getArgs, commandLineToArgv)
 import System.OsString.Windows
-import Graphics.Win32.Misc
-import Graphics.Win32.GDI.Types (COLORREF)
 
-import Foreign.C.Types (CInt(..))
-import Foreign.C.String (withCWString, CWString)
-import Foreign.Ptr (Ptr, plusPtr)
 import Foreign.Storable (Storable(..))
-import Foreign.Marshal.Array (peekArray, pokeArray)
+import Foreign.Marshal.Array (peekArray)
 import Foreign.Marshal.Alloc (alloca)
 
 

--- a/Win32.cabal
+++ b/Win32.cabal
@@ -1,3 +1,4 @@
+cabal-version:  2.0
 name:           Win32
 version:        2.13.4.0
 license:        BSD3
@@ -11,10 +12,10 @@ category:       System, Graphics
 synopsis:       A binding to Windows Win32 API.
 description:    This library contains direct bindings to the Windows Win32 APIs for Haskell.
 build-type:     Simple
-cabal-version:  2.0
 extra-source-files:
     include/diatemp.h include/dumpBMP.h include/ellipse.h include/errors.h
     include/Win32Aux.h include/win32debug.h include/alignment.h
+extra-doc-files:
     changelog.md
 
 flag os-string


### PR DESCRIPTION
Fixes #224

- Remove unused imports which lead to warnings (and errors with `-Werror`)
- Add a `filepath < 1.5` upper bound to the cabal file. (Edit: Changed upper bound to `1.4.200` which added a lot of deprecation warnings which fail with `-Werror`)
- Minor fix to the cabal file: `cabal-version` should be first field; `changelog.md` should be `extra-doc-file`.

This hopefully fixes the CI.