### PR TITLE
Adding ReadConsoleInput to the API.

### DIFF
--- a/System/Win32/Console/Internal.hsc
+++ b/System/Win32/Console/Internal.hsc
@@ -332,5 +332,5 @@ instance Storable INPUT_RECORD where
               FocusEvent `fmap` (#peek INPUT_RECORD, Event) buf
           _ -> error $ "Unknown input event type " ++ show event
 
-foreign import ccall unsafe "windows.h ReadConsoleInputW"
+foreign import WINDOWS_CCONV unsafe "windows.h ReadConsoleInputW"
     c_ReadConsoleInput :: HANDLE -> Ptr INPUT_RECORD -> DWORD -> LPDWORD -> IO BOOL


### PR DESCRIPTION
## Description
There are some new data types in Console/Internal.hsc to support the ReadConsoleInput API:
  KEY_EVENT_RECORD
  MOUSE_EVENT_RECORD
  WINDOW_BUFFER_SIZE_RECORD
  MENU_EVENT_RECORD
  FOCUS_EVENT_RECORD
  INPUT_RECORD

The exported function readConsoleInput is also added.

## Motivation and Context
There are several apps that have used the ReadConsoleInput Win32 API method. This
leads to a bit of code duplication. Since these apps already use the Win32 library, it
just makes sense to consolidate that code into one place.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have not added a new Haskell dependency.
- [ ] I have included a changelog entry.
- [x] I have not modified the version of the package in `Win32.cabal`.
