### PR TITLE
Add docs to System.Win32.File and System.Win32.File.Internal

### DIFF
--- a/System/Win32/File.hsc
+++ b/System/Win32/File.hsc
@@ -258,11 +258,15 @@ import Data.Maybe (fromMaybe)
 -- File operations
 ----------------------------------------------------------------
 
--- | like failIf, but retried on sharing violations.
+-- | Like 'failIf', but retried on sharing violations.
 -- This is necessary for many file operations; see
 --   https://www.betaarchive.com/wiki/index.php/Microsoft_KB_Archive/316609
 --
-failIfWithRetry :: (a -> Bool) -> String -> IO a -> IO a
+failIfWithRetry
+  :: (a -> Bool) -- ^ Predicate to check if the result indicates failure and a retry is needed.
+  -> String      -- ^ Error message to use if all retries fail.
+  -> IO a        -- ^ Action to perform.
+  -> IO a
 failIfWithRetry cond msg action = retryOrFail retries
   where
     delay   = 100*1000 -- in ms, we use threadDelay
@@ -282,65 +286,265 @@ failIfWithRetry cond msg action = retryOrFail retries
                 then do threadDelay delay; retryOrFail (times - 1)
                 else errorWin msg
 
-failIfWithRetry_ :: (a -> Bool) -> String -> IO a -> IO ()
+-- | Like 'failIfWithRetry', but discards the result.
+failIfWithRetry_
+  :: (a -> Bool) -- ^ Predicate to check if the result indicates failure and a retry is needed.
+  -> String      -- ^ Error message to use if all retries fail.
+  -> IO a        -- ^ Action to perform.
+  -> IO ()
 failIfWithRetry_ cond msg action = void $ failIfWithRetry cond msg action
 
-failIfFalseWithRetry_ :: String -> IO Bool -> IO ()
+-- | Like 'failIfWithRetry_', but now the predicate is the result of the action.
+failIfFalseWithRetry_
+  :: String  -- ^ Error message to use if all retries fail.
+  -> IO Bool -- ^ Bool action to perform.
+  -> IO ()
 failIfFalseWithRetry_ = failIfWithRetry_ not
 
-deleteFile :: String -> IO ()
+-- | Deletes the specified file.
+-- If the file does not exist or cannot be deleted, an exception is thrown.
+--
+-- Note on atomicity:
+-- File deletion is not guaranteed to be atomic. For example, if the file is open
+-- in another process, deletion may be delayed until all handles are closed. Also,
+-- in case of a system crash or power failure, the file may remain on disk or be
+-- only partially deleted.
+--
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND      2   (0x2)
+-- ERROR_PATH_NOT_FOUND      3   (0x3)
+-- ERROR_ACCESS_DENIED       5   (0x5)
+-- ERROR_CURRENT_DIRECTORY  16   (0x10)
+-- ERROR_WRITE_PROTECT      19   (0x13)
+-- ERROR_SHARING_VIOLATION  32   (0x20)
+-- ERROR_LOCK_VIOLATION     33   (0x21)
+-- ERROR_INVALID_PARAMETER  87   (0x57)
+-- ERROR_USER_MAPPED_FILE 1224   (0x4C8)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-deletefilew
+deleteFile
+  :: String  -- ^ Path to the file to delete
+  -> IO ()
 deleteFile name =
   withFilePath name $ \ c_name ->
     failIfFalseWithRetry_ (unwords ["DeleteFile",show name]) $
       c_DeleteFile c_name
 
-copyFile :: String -> String -> Bool -> IO ()
+-- | Copies a file from a source path to a destination path, with an option to
+-- overwrite the destination file if it exists.
+-- 
+-- Note on atomicity:
+-- File copying is not guaranteed to be atomic. For example, if a system crash or
+-- power failure occurs during the copy, the destination file may be left incomplete
+-- or corrupted.
+--
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND      2   (0x2)
+-- ERROR_PATH_NOT_FOUND      3   (0x3)
+-- ERROR_ACCESS_DENIED       5   (0x5)
+-- ERROR_SHARING_VIOLATION  32  (0x20)
+-- ERROR_FILE_EXISTS        80  (0x50)
+-- ERROR_ALREADY_EXISTS    183  (0xB7)
+-- ERROR_INVALID_PARAMETER  87  (0x57)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-copyfilew
+copyFile
+  :: String  -- ^ Path to the source file
+  -> String  -- ^ Path to the destination file
+  -> Bool    -- ^ True to overwrite the destination if it exists, False to prevent overwriting
+  -> IO ()
 copyFile src dest over =
   withFilePath src $ \ c_src ->
   withFilePath dest $ \ c_dest ->
   failIfFalseWithRetry_ (unwords ["CopyFile",show src,show dest]) $
     c_CopyFile c_src c_dest over
 
-moveFile :: String -> String -> IO ()
+-- | Moves a file from a source path to a destination path.
+--
+-- Note on atomicity:
+-- File moving is not guaranteed to be atomic. For example, if the move occurs
+-- across different volumes, it is implemented as a copy followed by a delete,
+-- so a system crash or error during the operation may leave the destination file
+-- incomplete or the source file undeleted.
+--
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND      2   (0x2)
+-- ERROR_PATH_NOT_FOUND      3   (0x3)
+-- ERROR_ACCESS_DENIED       5   (0x5)
+-- ERROR_ALREADY_EXISTS    183  (0xB7)
+-- ERROR_SHARING_VIOLATION  32  (0x20)
+-- ERROR_NOT_SAME_DEVICE    17  (0x11)
+-- ERROR_INVALID_PARAMETER  87  (0x57)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefilew
+moveFile
+  :: String  -- ^ Path to the source file
+  -> String  -- ^ Path to the destination file
+  -> IO ()
 moveFile src dest =
   withFilePath src $ \ c_src ->
   withFilePath dest $ \ c_dest ->
   failIfFalseWithRetry_ (unwords ["MoveFile",show src,show dest]) $
     c_MoveFile c_src c_dest
 
-moveFileEx :: String -> Maybe String -> MoveFileFlag -> IO ()
+-- | Moves or renames a file or directory, with additional options specified by flags.
+-- The destination path can be Nothing to perform certain operations (such as deleting
+-- the file, depending on the flags).
+-- 
+-- Note on atomicity:
+-- Atomicity depends on the flags and the file system. For example, using
+-- MOVEFILE_REPLACE_EXISTING with source and destination on the same volume is typically
+-- atomic (rename). If MOVEFILE_COPY_ALLOWED is used or the operation is across different
+-- volumes, the move is performed as a copy followed by a delete, which is not atomic.
+--
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND      2   (0x2)
+-- ERROR_PATH_NOT_FOUND      3   (0x3)
+-- ERROR_ACCESS_DENIED       5   (0x5)
+-- ERROR_ALREADY_EXISTS    183  (0xB7)
+-- ERROR_SHARING_VIOLATION  32  (0x20)
+-- ERROR_NOT_SAME_DEVICE    17  (0x11)
+-- ERROR_INVALID_PARAMETER  87  (0x57)
+-- ERROR_WRITE_PROTECT      19  (0x13)
+-- ERROR_LOCK_VIOLATION     33  (0x21)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexw
+moveFileEx
+  :: String           -- ^ Path to the source file or directory
+  -> Maybe String     -- ^ Path to the destination file or directory, or Nothing
+  -> MoveFileFlag     -- ^ Flags that control the move operation
+  -> IO ()
 moveFileEx src dest flags =
   withFilePath src $ \ c_src ->
   maybeWith withFilePath dest $ \ c_dest ->
   failIfFalseWithRetry_ (unwords ["MoveFileEx",show src,show dest]) $
     c_MoveFileEx c_src c_dest flags
 
-setCurrentDirectory :: String -> IO ()
+-- | Sets the current working directory for the process to the specified path.
+--
+-- Note on atomicity:
+-- Setting the current directory is an atomic operation for the process, but it only
+-- affects the current process and its threads. Other processes are not affected.
+--
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND      2   (0x2)
+-- ERROR_PATH_NOT_FOUND      3   (0x3)
+-- ERROR_ACCESS_DENIED       5   (0x5)
+-- ERROR_INVALID_PARAMETER  87   (0x57)
+-- ERROR_DIRECTORY         267   (0x10B)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setcurrentdirectory
+setCurrentDirectory
+  :: String  -- ^ Path to the new current directory
+  -> IO ()
 setCurrentDirectory name =
   withFilePath name $ \ c_name ->
   failIfFalse_ (unwords ["SetCurrentDirectory",show name]) $
     c_SetCurrentDirectory c_name
 
-createDirectory :: String -> Maybe LPSECURITY_ATTRIBUTES -> IO ()
+-- | Creates a new directory with the specified path and optional security attributes.
+-- If the directory already exists, the operation fails.
+--
+-- Note on atomicity:
+-- Directory creation is generally atomic at the file system level, but if a system
+-- crash or power failure occurs during the operation, the directory may be left
+-- in an incomplete state or not created at all.
+--
+-- Possible errors:
+-- ERROR_ALREADY_EXISTS         183  (0xB7)
+-- ERROR_PATH_NOT_FOUND           3  (0x3)
+-- ERROR_ACCESS_DENIED            5  (0x5)
+-- ERROR_INVALID_PARAMETER       87  (0x57)
+-- ERROR_FILENAME_EXCED_RANGE   206  (0xCE)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createdirectoryw
+createDirectory
+  :: String                      -- ^ Path to the new directory
+  -> Maybe LPSECURITY_ATTRIBUTES -- ^ Optional security attributes, or Nothing for defaults
+  -> IO ()
 createDirectory name mb_attr =
   withFilePath name $ \ c_name ->
   failIfFalseWithRetry_ (unwords ["CreateDirectory",show name]) $
     c_CreateDirectory c_name (maybePtr mb_attr)
 
-createDirectoryEx :: String -> String -> Maybe LPSECURITY_ATTRIBUTES -> IO ()
+-- | Creates a new directory with the specified path, optionally copying the security
+-- attributes from an existing template directory and allowing custom security attributes.
+-- If the directory already exists, the operation fails.
+--
+-- Note on atomicity:
+-- Directory creation is generally atomic at the file system level, but if a system
+-- crash or power failure occurs during the operation, the directory may be left
+-- in an incomplete state or not created at all.
+--
+-- Possible errors:
+-- ERROR_ALREADY_EXISTS         183  (0xB7)
+-- ERROR_PATH_NOT_FOUND           3  (0x3)
+-- ERROR_ACCESS_DENIED            5  (0x5)
+-- ERROR_INVALID_PARAMETER       87  (0x57)
+-- ERROR_FILENAME_EXCED_RANGE   206  (0xCE)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createdirectoryexw
+createDirectoryEx
+  :: String                      -- ^ Path to the template directory (to copy attributes from)
+  -> String                      -- ^ Path to the new directory
+  -> Maybe LPSECURITY_ATTRIBUTES -- ^ Optional security attributes, or Nothing for defaults
+  -> IO ()
 createDirectoryEx template name mb_attr =
   withFilePath template $ \ c_template ->
   withFilePath name $ \ c_name ->
   failIfFalseWithRetry_ (unwords ["CreateDirectoryEx",show template,show name]) $
     c_CreateDirectoryEx c_template c_name (maybePtr mb_attr)
 
-removeDirectory :: String -> IO ()
+-- | Removes (deletes) the directory at the specified path.
+-- The directory must be empty for the operation to succeed.
+--
+-- Note on atomicity:
+-- Directory removal is generally atomic at the file system level, but if a system
+-- crash or power failure occurs during the operation, the directory may be left
+-- partially removed or still present.
+--
+-- Possible errors:
+-- ERROR_PATH_NOT_FOUND           3   (0x3)
+-- ERROR_ACCESS_DENIED            5   (0x5)
+-- ERROR_SHARING_VIOLATION       32   (0x20)
+-- ERROR_INVALID_PARAMETER       87   (0x57)
+-- ERROR_DIRECTORY              267   (0x10B)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-removedirectoryw
+removeDirectory
+  :: String  -- ^ Path to the directory to remove
+  -> IO ()
 removeDirectory name =
   withFilePath name $ \ c_name ->
   failIfFalseWithRetry_ (unwords ["RemoveDirectory",show name]) $
     c_RemoveDirectory c_name
 
-getBinaryType :: String -> IO BinaryType
+-- | Retrieves the binary type of the specified executable file.
+-- Returns an integer code indicating the type (e.g., 32-bit, 64-bit, DOS, etc.).
+--
+-- Note on atomicity:
+-- This operation is atomic in the sense that it simply queries file metadata and
+-- does not modify the file or its contents.
+--
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND           2   (0x2)
+-- ERROR_PATH_NOT_FOUND           3   (0x3)
+-- ERROR_INVALID_PARAMETER       87   (0x57)
+-- ERROR_BAD_EXE_FORMAT         193   (0xC1)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getbinarytypew
+getBinaryType
+  :: String  -- ^ Path to the executable file
+  -> IO BinaryType
 getBinaryType name =
   withFilePath name $ \ c_name ->
   alloca $ \ p_btype -> do
@@ -348,12 +552,25 @@ getBinaryType name =
     c_GetBinaryType c_name p_btype
   peek p_btype
 
--- | Get a unique temporary filename.
+-- | Get a unique temporary filename. Returns the full path of the new temporary file.
 --
--- Calls 'GetTempFileNameW'.
-getTempFileName :: String     -- ^ directory for the temporary file (must be at most MAX_PATH - 14 characters long)
-                -> String     -- ^ prefix for the temporary file name
-                -> Maybe UINT -- ^ if 'Nothing', a unique name is generated
+-- Note on atomicity:
+-- The creation of the temporary file is not guaranteed to be atomic. If a system
+-- crash or power failure occurs during the operation, the file may not be created
+-- or may be left in an incomplete state.
+--
+-- Possible errors:
+-- ERROR_DIRECTORY              267   (0x10B)
+-- ERROR_ACCESS_DENIED            5   (0x5)
+-- ERROR_INVALID_PARAMETER       87   (0x57)
+-- ERROR_BUFFER_OVERFLOW        111   (0x6F)
+-- ERROR_FILE_EXISTS             80   (0x50)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettempfilenamew
+getTempFileName :: String     -- ^ Directory for the temporary file (must be at most MAX_PATH - 14 characters long)
+                -> String     -- ^ Prefix for the temporary file name
+                -> Maybe UINT -- ^ If 'Nothing', a unique name is generated
                               --   otherwise a non-zero value is used as the unique part
                 -> IO (String, UINT)
 getTempFileName dir prefix unique = allocaBytes ((#const MAX_PATH) * sizeOf (undefined :: TCHAR)) $ \c_buf -> do
@@ -368,10 +585,42 @@ getTempFileName dir prefix unique = allocaBytes ((#const MAX_PATH) * sizeOf (und
 -- HANDLE operations
 ----------------------------------------------------------------
 
-createFile :: String -> AccessMode -> ShareMode -> Maybe LPSECURITY_ATTRIBUTES -> CreateMode -> FileAttributeOrFlag -> Maybe HANDLE -> IO HANDLE
+-- | Opens or creates a file or device with the specified access, sharing mode,
+-- security attributes, creation disposition, flags, and optional template handle.
+-- Returns a HANDLE to the opened or created file or device.
+--
+-- Note on atomicity:
+-- File creation or opening is generally atomic at the file system level, but if a
+-- system crash or power failure occurs during the operation, the file may be left
+-- in an incomplete state or not created at all.
+--
+-- Possible errors:
+-- ERROR_ALREADY_EXISTS    183   (0xB7)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew
+createFile
+  :: String                      -- ^ Path to the file or device
+  -> AccessMode                  -- ^ Desired access mode
+  -> ShareMode                   -- ^ Sharing mode
+  -> Maybe LPSECURITY_ATTRIBUTES -- ^ Optional security attributes
+  -> CreateMode                  -- ^ Action to take on files that exist or do not exist
+  -> FileAttributeOrFlag         -- ^ File or device attributes and flags
+  -> Maybe HANDLE                -- ^ Optional template file handle
+  -> IO HANDLE
 createFile = createFile' failIfWithRetry
 
-createFile' :: ((HANDLE -> Bool) -> String -> IO HANDLE -> IO HANDLE) -> String -> AccessMode -> ShareMode -> Maybe LPSECURITY_ATTRIBUTES -> CreateMode -> FileAttributeOrFlag -> Maybe HANDLE -> IO HANDLE
+-- | Internal function for defining the behavior of 'createFile'.
+createFile'
+  :: ((HANDLE -> Bool) -> String -> IO HANDLE -> IO HANDLE)
+  -> String                      -- ^ Path to the file or device
+  -> AccessMode                  -- ^ Desired access mode
+  -> ShareMode                   -- ^ Sharing mode
+  -> Maybe LPSECURITY_ATTRIBUTES -- ^ Optional security attributes
+  -> CreateMode                  -- ^ Action to take on files that exist or do not exist
+  -> FileAttributeOrFlag         -- ^ File or device attributes and flags
+  -> Maybe HANDLE                -- ^ Optional template file handle
+  -> IO HANDLE
 createFile' f name access share mb_attr mode flag mb_h =
   withFilePath name $ \ c_name ->
   f (==iNVALID_HANDLE_VALUE) (unwords ["CreateFile",show name]) $
@@ -379,71 +628,308 @@ createFile' f name access share mb_attr mode flag mb_h =
 
 -- | Like createFile, but does not use failIfWithRetry. If another
 -- process has the same file open, this will fail.
-createFile_NoRetry :: String -> AccessMode -> ShareMode -> Maybe LPSECURITY_ATTRIBUTES -> CreateMode -> FileAttributeOrFlag -> Maybe HANDLE -> IO HANDLE
+--
+-- Note on atomicity:
+-- File creation or opening is generally atomic at the file system level, but if a
+-- system crash or power failure occurs during the operation, the file may be left
+-- in an incomplete state or not created at all.
+--
+-- Possible errors:
+-- ERROR_ALREADY_EXISTS    183   (0xB7)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew
+createFile_NoRetry
+  :: String                      -- ^ Path to the file or device
+  -> AccessMode                  -- ^ Desired access mode
+  -> ShareMode                   -- ^ Sharing mode
+  -> Maybe LPSECURITY_ATTRIBUTES -- ^ Optional security attributes
+  -> CreateMode                  -- ^ Action to take on files that exist or do not exist
+  -> FileAttributeOrFlag         -- ^ File or device attributes and flags
+  -> Maybe HANDLE                -- ^ Optional template file handle
+  -> IO HANDLE
 createFile_NoRetry = createFile' failIf
 
-closeHandle :: HANDLE -> IO ()
+-- | Closes an open object handle, such as a file, process, thread, or other system resource.
+-- After closing, the handle is no longer valid.
+--
+-- Note on atomicity:
+-- Closing a handle is atomic with respect to the handle itself: after the call,
+-- the handle is either valid or closed, with no intermediate state. However,
+-- resources associated with the handle may be released asynchronously by the system.
+--
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND           2   (0x2)
+-- ERROR_PATH_NOT_FOUND           3   (0x3)
+-- ERROR_ACCESS_DENIED            5   (0x5)
+-- ERROR_WRITE_PROTECT           19   (0x13)
+-- ERROR_INVALID_HANDLE           6   (0x6)
+-- ERROR_SHARING_VIOLATION       32   (0x20)
+-- ERROR_FILE_EXISTS             80   (0x50)
+-- ERROR_ALREADY_EXISTS         183   (0xB7)
+-- ERROR_INVALID_PARAMETER       87   (0x57)
+-- ERROR_INVALID_NAME           123   (0x7B)
+-- ERROR_DISK_FULL              112   (0x70)
+-- ERROR_DIRECTORY              267   (0x10B)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-closehandle
+closeHandle
+  :: HANDLE  -- ^ Handle to be closed
+  -> IO ()
 closeHandle h =
   failIfFalse_ "CloseHandle" $ c_CloseHandle h
 
---Apparently no error code
-
-flushFileBuffers :: HANDLE -> IO ()
+-- | Flushes the buffers of a file to disk, ensuring that all buffered data for the
+-- specified file handle is written to the storage device.
+--
+-- Note on atomicity:
+-- Flushing file buffers is atomic with respect to the flush request: all data buffered
+-- for the file is written to disk as a single operation. However, if a system crash or
+-- power failure occurs during the flush, some data may not be fully written.
+--
+-- Possible errors:
+-- ERROR_INVALID_HANDLE    6   (0x6)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-flushfilebuffers
+flushFileBuffers
+  :: HANDLE  -- ^ Handle to the file whose buffers are to be flushed
+  -> IO ()
 flushFileBuffers h =
   failIfFalse_ "FlushFileBuffers" $ c_FlushFileBuffers h
 
-setEndOfFile :: HANDLE -> IO ()
+-- | Sets the end of the file at the current file pointer position for the specified handle.
+-- This truncates or extends the file as needed.
+--
+-- Note on atomicity:
+-- Setting the end of file is generally atomic at the file system level. However, if a
+-- system crash or power failure occurs during the operation, the file may be left in an
+-- inconsistent or partially updated state.
+--
+-- Possible errors:
+-- ERROR_INVALID_HANDLE    6   (0x6)
+-- ERROR_ACCESS_DENIED     5   (0x5)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setendoffile
+setEndOfFile
+  :: HANDLE  -- ^ Handle to the file
+  -> IO ()
 setEndOfFile h =
   failIfFalse_ "SetEndOfFile" $ c_SetEndOfFile h
 
-setFileAttributes :: String -> FileAttributeOrFlag -> IO ()
+-- | Sets the attributes for the specified file or directory.
+-- Common attributes include read-only, hidden, system, etc.
+--
+-- Note on atomicity:
+-- Setting file attributes is generally atomic at the file system level. However, if a
+-- system crash or power failure occurs during the operation, the attributes may not be
+-- updated or may be left in an inconsistent state.
+--
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND            2   (0x2)
+-- ERROR_PATH_NOT_FOUND            3   (0x3)
+-- ERROR_ACCESS_DENIED             5   (0x5)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfileattributesw
+setFileAttributes
+  :: String               -- ^ Path to the file or directory
+  -> FileAttributeOrFlag  -- ^ Attributes to set
+  -> IO ()
 setFileAttributes name attr =
   withFilePath name $ \ c_name ->
   failIfFalseWithRetry_ (unwords ["SetFileAttributes",show name])
     $ c_SetFileAttributes c_name attr
 
-getFileAttributes :: String -> IO FileAttributeOrFlag
+-- | Retrieves the attributes of the specified file or directory.
+-- Returns a set of flags indicating attributes such as read-only, hidden, system, etc.
+--
+-- Note on atomicity:
+-- Retrieving file attributes is atomic: the operation simply queries the current
+-- metadata of the file or directory and does not modify any data.
+--
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND            2   (0x2)
+-- ERROR_PATH_NOT_FOUND            3   (0x3)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfileattributesw
+getFileAttributes
+  :: String               -- ^ Path to the file or directory
+  -> IO FileAttributeOrFlag
 getFileAttributes name =
   withFilePath name $ \ c_name ->
   failIfWithRetry (== 0xFFFFFFFF) (unwords ["GetFileAttributes",show name]) $
     c_GetFileAttributes c_name
 
-getFileAttributesExStandard :: String -> IO WIN32_FILE_ATTRIBUTE_DATA
+-- | Retrieves extended attribute information for the specified file or directory,
+-- including size, timestamps, and standard attributes.
+--
+-- Note on atomicity:
+-- Retrieving extended file attributes is atomic: the operation only queries the current
+-- metadata of the file or directory and does not modify any data.
+--
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND            2   (0x2)
+-- ERROR_PATH_NOT_FOUND            3   (0x3)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfileattributesexw
+getFileAttributesExStandard
+  :: String                        -- ^ Path to the file or directory
+  -> IO WIN32_FILE_ATTRIBUTE_DATA  -- ^ Structure containing the attribute data
 getFileAttributesExStandard name =  alloca $ \res -> do
   withFilePath name $ \ c_name ->
     failIfFalseWithRetry_ "getFileAttributesExStandard" $
       c_GetFileAttributesEx c_name getFileExInfoStandard res
   peek res
 
-getFileInformationByHandle :: HANDLE -> IO BY_HANDLE_FILE_INFORMATION
+-- | Retrieves information about a file based on its handle, including attributes,
+-- size, timestamps, and volume information.
+--
+-- Note on atomicity:
+-- Retrieving file information by handle is atomic: the operation only queries the current
+-- metadata of the file and does not modify any data.
+--
+-- Possible errors:
+-- ERROR_INVALID_HANDLE            6   (0x6)
+-- ERROR_ACCESS_DENIED             5   (0x5)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfileinformationbyhandle
+getFileInformationByHandle
+  :: HANDLE                        -- ^ Handle to the file
+  -> IO BY_HANDLE_FILE_INFORMATION -- ^ Structure containing the file information
 getFileInformationByHandle h = alloca $ \res -> do
-    failIfFalseWithRetry_ "GetFileInformationByHandle" $ c_GetFileInformationByHandle h res
-    peek res
+  failIfFalseWithRetry_ "GetFileInformationByHandle" $ c_GetFileInformationByHandle h res
+  peek res
 
-replaceFile :: LPCWSTR -> LPCWSTR -> LPCWSTR -> DWORD -> IO ()
+-- | Replaces one file with another, optionally creating a backup and specifying
+-- replacement options.
+-- 
+-- Note on atomicity:
+-- File replacement is typically atomic when both files are on the same volume and
+-- no special file system features interfere. If the files are on different volumes,
+-- or if a system crash or power failure occurs during the operation, atomicity is
+-- not guaranteed and the destination file may be left in an inconsistent state.
+--
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND                  2   (0x2)
+-- ERROR_PATH_NOT_FOUND                  3   (0x3)
+-- ERROR_ACCESS_DENIED                   5   (0x5)
+-- ERROR_SHARING_VIOLATION              32   (0x20)
+-- ERROR_INVALID_PARAMETER              87   (0x57)
+-- ERROR_UNABLE_TO_REMOVE_REPLACED    1175   (0x497)
+-- ERROR_UNABLE_TO_MOVE_REPLACEMENT   1176   (0x498)
+-- ERROR_UNABLE_TO_MOVE_REPLACEMENT_2 1177   (0x499)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-replacefilew
+replaceFile
+  :: LPCWSTR   -- ^ replacedFile: path to the file to be replaced
+  -> LPCWSTR   -- ^ replacementFile: path to the replacement file
+  -> LPCWSTR   -- ^ backupFile: path to the backup file, or NULL if no backup is needed
+  -> DWORD     -- ^ replaceFlags: flags that control the replacement operation
+  -> IO ()
 replaceFile replacedFile replacementFile backupFile replaceFlags =
-  failIfFalse_ "ReplaceFile" $ c_ReplaceFile replacedFile replacementFile backupFile replaceFlags nullPtr nullPtr
+  failIfFalse_ "ReplaceFile" $
+    c_ReplaceFile replacedFile replacementFile backupFile replaceFlags nullPtr nullPtr
 
 ----------------------------------------------------------------
 -- Read/write files
 ----------------------------------------------------------------
 
---Sigh - I give up & prefix win32_ to the next two to avoid
--- senseless Prelude name clashes. --sof.
-
-win32_ReadFile :: HANDLE -> Ptr a -> DWORD -> Maybe LPOVERLAPPED -> IO DWORD
+-- | Reads data from a file or input/output (I/O) device into a buffer.
+-- Supports both synchronous and asynchronous (overlapped) operations.
+-- Returns the number of bytes read.
+--
+-- Note on atomicity:
+-- Each read operation is atomic with respect to the requested range: the data read
+-- is either from before or after the call, with no partial modification by other
+-- processes in between. However, if a system crash or power failure occurs during
+-- the read, the operation may not complete or may return incomplete data.
+--
+-- Possible errors:
+-- ERROR_ACCESS_DENIED             5   (0x5)
+-- ERROR_INVALID_HANDLE            6   (0x6)
+-- ERROR_HANDLE_EOF               38   (0x26)
+-- ERROR_BROKEN_PIPE             109   (0x6D)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+-- ERROR_IO_PENDING              997   (0x3E5)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-readfile
+win32_ReadFile
+  :: HANDLE             -- ^ Handle to the file or I/O device
+  -> Ptr a              -- ^ Pointer to the buffer that receives the data
+  -> DWORD              -- ^ Number of bytes to read
+  -> Maybe LPOVERLAPPED -- ^ Optional pointer to an OVERLAPPED structure for asynchronous operations
+  -> IO DWORD           -- ^ Number of bytes actually read
 win32_ReadFile h buf n mb_over =
   alloca $ \ p_n -> do
   failIfFalse_ "ReadFile" $ c_ReadFile h buf n p_n (maybePtr mb_over)
   peek p_n
 
-win32_WriteFile :: HANDLE -> Ptr a -> DWORD -> Maybe LPOVERLAPPED -> IO DWORD
+-- | Writes data to a file or input/output (I/O) device from a buffer.
+-- Supports both synchronous and asynchronous (overlapped) operations.
+-- Returns the number of bytes written.
+--
+-- Note on atomicity:
+-- Each write operation is atomic with respect to the requested range: the data is
+-- either fully written or not written at all for the specified region. However, if a
+-- system crash or power failure occurs during the write, the file may be left in an
+-- incomplete or inconsistent state.
+--
+-- Possible errors:
+-- ERROR_ACCESS_DENIED             5   (0x5)
+-- ERROR_INVALID_HANDLE            6   (0x6)
+-- ERROR_HANDLE_EOF               38   (0x26)
+-- ERROR_BROKEN_PIPE             109   (0x6D)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+-- ERROR_DISK_FULL               112   (0x70)
+-- ERROR_IO_PENDING              997   (0x3E5)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-writefile
+win32_WriteFile
+  :: HANDLE             -- ^ Handle to the file or I/O device
+  -> Ptr a              -- ^ Pointer to the buffer containing the data to write
+  -> DWORD              -- ^ Number of bytes to write
+  -> Maybe LPOVERLAPPED -- ^ Optional pointer to an OVERLAPPED structure for asynchronous operations
+  -> IO DWORD           -- ^ Number of bytes actually written
 win32_WriteFile h buf n mb_over =
   alloca $ \ p_n -> do
   failIfFalse_ "WriteFile" $ c_WriteFile h buf n p_n (maybePtr mb_over)
   peek p_n
 
-setFilePointerEx :: HANDLE -> LARGE_INTEGER -> FilePtrDirection -> IO LARGE_INTEGER
+-- | Moves the file pointer of the specified file handle to a new position.
+-- The position is set relative to the beginning, current position, or end of the file,
+-- depending on the direction argument. Returns the new file pointer position.
+--
+-- Note on atomicity:
+-- Setting the file pointer is atomic with respect to the handle: the position is
+-- updated in a single operation. However, this does not affect the file contents,
+-- and a system crash or power failure during subsequent operations may still cause
+-- inconsistencies.
+--
+-- Possible errors:
+-- ERROR_INVALID_HANDLE            6   (0x6)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+-- ERROR_NEGATIVE_SEEK           131   (0x83)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfilepointerex
+setFilePointerEx
+  :: HANDLE           -- ^ Handle to the file
+  -> LARGE_INTEGER    -- ^ Distance to move the file pointer
+  -> FilePtrDirection -- ^ Reference point for the move (beginning, current, or end)
+  -> IO LARGE_INTEGER -- ^ New file pointer position
 setFilePointerEx h dist dir =
   alloca $ \p_pos -> do
   failIfFalse_ "SetFilePointerEx" $ c_SetFilePointerEx h dist p_pos dir
@@ -456,17 +942,68 @@ setFilePointerEx h dist dir =
 -- on.
 ----------------------------------------------------------------
 
-findFirstChangeNotification :: String -> Bool -> FileNotificationFlag -> IO HANDLE
+-- | Creates a change notification handle for a directory, allowing you to monitor
+-- changes to files or subdirectories. Returns a handle that can be used with
+-- wait functions to detect changes.
+--
+-- Note on atomicity:
+-- The creation of a change notification handle is atomic with respect to the request:
+-- the handle is either created and ready to monitor changes, or the operation fails.
+-- However, there may be a delay between the actual file system change and its detection,
+-- and some rapid changes may not be observed if they occur between polling intervals.
+--
+-- Possible errors:
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+-- ERROR_PATH_NOT_FOUND            3   (0x3)
+-- ERROR_ACCESS_DENIED             5   (0x5)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstchangenotificationw
+findFirstChangeNotification
+  :: String               -- ^ Path to the directory to monitor
+  -> Bool                 -- ^ True to monitor subdirectories, False otherwise
+  -> FileNotificationFlag -- ^ Filter specifying which changes to monitor
+  -> IO HANDLE            -- ^ Notification handle
 findFirstChangeNotification path watch flag =
   withFilePath path $ \ c_path ->
   failIfNull (unwords ["FindFirstChangeNotification",show path]) $
     c_FindFirstChangeNotification c_path watch flag
 
-findNextChangeNotification :: HANDLE -> IO ()
+-- | Requests the next change notification for a directory being monitored.
+-- Use after a previous change has been detected to continue monitoring.
+--
+-- Note on atomicity:
+-- Requesting the next change notification is atomic with respect to the handle:
+-- the monitoring state is updated in a single operation. However, there may be a delay
+-- between the actual file system change and its detection, and some rapid changes may
+-- not be observed if they occur between notifications.
+--
+-- Possible errors:
+-- ERROR_INVALID_HANDLE    6   (0x6)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findnextchangenotification
+findNextChangeNotification
+  :: HANDLE  -- ^ Notification handle returned by findFirstChangeNotification
+  -> IO ()
 findNextChangeNotification h =
   failIfFalse_ "FindNextChangeNotification" $ c_FindNextChangeNotification h
 
-findCloseChangeNotification :: HANDLE -> IO ()
+-- | Closes a change notification handle and releases associated system resources.
+--
+-- Note on atomicity:
+-- Closing a change notification handle is atomic with respect to the handle: after the call,
+-- the handle is either valid or closed, with no intermediate state. This does not affect
+-- the state of the monitored directory or pending notifications.
+--
+-- Possible errors:
+-- ERROR_INVALID_HANDLE    6   (0x6)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findclosechangenotification
+findCloseChangeNotification
+  :: HANDLE  -- ^ Notification handle to close
+  -> IO ()
 findCloseChangeNotification h =
   failIfFalse_ "FindCloseChangeNotification" $ c_FindCloseChangeNotification h
 
@@ -474,12 +1011,41 @@ findCloseChangeNotification h =
 -- Directories
 ----------------------------------------------------------------
 
-getFindDataFileName :: FindData -> IO FilePath
+-- | Extracts the file name from a FindData structure, which is typically obtained
+-- from file search operations (e.g., FindFirstFile/FindNextFile).
+--
+-- Note on atomicity:
+-- Extracting the file name from a FindData structure is atomic: it simply reads
+-- the value from memory and does not modify any file system state.
+getFindDataFileName
+  :: FindData   -- ^ FindData structure containing file information
+  -> IO FilePath
 getFindDataFileName (FindData fp) =
   withForeignPtr fp $ \p ->
     peekTString ((# ptr WIN32_FIND_DATAW, cFileName ) p)
 
-findFirstFile :: String -> IO (HANDLE, FindData)
+-- | Begins a file search in a directory that matches a given pattern (e.g., "*.txt").
+-- Returns a tuple containing a search handle and a FindData structure with information
+-- about the first matching file. The handle should be closed with findClose when done.
+--
+-- Note on atomicity:
+-- Starting a file search is atomic with respect to the creation of the search handle:
+-- the handle is either created and ready for enumeration, or the operation fails.
+-- The file system contents may change during enumeration, so results may not reflect
+-- a consistent snapshot if files are added or removed during the search.
+--
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND            2   (0x2)
+-- ERROR_PATH_NOT_FOUND            3   (0x3)
+-- ERROR_ACCESS_DENIED             5   (0x5)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+-- ERROR_INVALID_HANDLE            6   (0x6)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstfilew
+findFirstFile
+  :: String                -- ^ Search pattern (e.g., file name or wildcard)
+  -> IO (HANDLE, FindData) -- ^ Search handle and data for the first matching file
 findFirstFile str = do
   fp_finddata <- mallocForeignPtrBytes (# const sizeof(WIN32_FIND_DATAW) )
   withForeignPtr fp_finddata $ \p_finddata -> do
@@ -488,7 +1054,29 @@ findFirstFile str = do
                   c_FindFirstFile tstr p_finddata
     return (handle, FindData fp_finddata)
 
-findNextFile :: HANDLE -> FindData -> IO Bool -- False -> no more files
+-- | Continues a file search from a previous findFirstFile call.
+-- Updates the FindData structure with information about the next matching file.
+-- Returns True if a file is found, or False if there are no more files.
+-- Throws an exception if another error occurs.
+--
+-- Note on atomicity:
+-- Retrieving the next file in a search is atomic with respect to the search handle:
+-- each call returns information about a single file or signals completion. However,
+-- the file system may change between calls, so the enumeration may not reflect a
+-- consistent snapshot if files are added or removed during the search.
+--
+-- Possible errors:
+-- ERROR_NO_MORE_FILES            18   (0x12)
+-- ERROR_INVALID_HANDLE            6   (0x6)
+-- ERROR_ACCESS_DENIED             5   (0x5)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findnextfilew
+findNextFile
+  :: HANDLE     -- ^ Search handle from findFirstFile
+  -> FindData   -- ^ FindData structure to receive information about the next file
+  -> IO Bool    -- ^ True if a file is found, False if no more files
 findNextFile h (FindData finddata) = do
   withForeignPtr finddata $ \p_finddata -> do
     b <- c_FindNextFile h p_finddata
@@ -500,14 +1088,48 @@ findNextFile h (FindData finddata) = do
                 then return False
                 else failWith "findNextFile" err_code
 
-findClose :: HANDLE -> IO ()
+-- | Closes a file search handle created by findFirstFile and releases associated resources.
+--
+-- Note on atomicity:
+-- Closing a search handle is atomic with respect to the handle: after the call,
+-- the handle is either valid or closed, with no intermediate state. This does not
+-- affect the state of the file system or files being enumerated.
+--
+-- Possible errors:
+-- ERROR_INVALID_HANDLE    6   (0x6)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findclose
+findClose
+  :: HANDLE  -- ^ Search handle to close
+  -> IO ()
 findClose h = failIfFalse_ "findClose" $ c_FindClose h
 
 ----------------------------------------------------------------
 -- DOS Device flags
 ----------------------------------------------------------------
 
-defineDosDevice :: DefineDosDeviceFlags -> String -> Maybe String -> IO ()
+-- | Defines, modifies, or deletes a DOS device name (such as a drive letter or symbolic link).
+-- The flags control the operation (e.g., add, remove, or update a device mapping).
+-- The path argument is optional and may be Nothing when deleting a device name.
+--
+-- Note on atomicity:
+-- Defining, modifying, or deleting a DOS device name is atomic with respect to the device mapping:
+-- the mapping is either updated or not, with no intermediate state visible to other processes.
+-- However, changes may not be immediately visible to all processes due to system caching.
+--
+-- Possible errors:
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+-- ERROR_ACCESS_DENIED             5   (0x5)
+-- ERROR_FILE_NOT_FOUND            2   (0x2)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-definedosdevicew
+defineDosDevice
+  :: DefineDosDeviceFlags -- ^ Flags that control the operation
+  -> String               -- ^ Device name (e.g., drive letter or symbolic link)
+  -> Maybe String         -- ^ Optional target path for the device name
+  -> IO ()
 defineDosDevice flags name path =
   maybeWith withFilePath path $ \ c_path ->
   withFilePath name $ \ c_name ->
@@ -515,13 +1137,43 @@ defineDosDevice flags name path =
 
 ----------------------------------------------------------------
 
-getLogicalDrives :: IO DWORD
+-- | Retrieves a bitmask representing the currently available disk drives.
+-- Each bit in the result corresponds to a drive letter (A: = bit 0, B: = bit 1, etc.).
+--
+-- Note on atomicity:
+-- Retrieving the logical drives bitmask is atomic: the operation queries the current
+-- state of the system and does not modify any data.
+--
+-- Possible errors:
+-- ERROR_INVALID_FUNCTION          1   (0x1)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getlogicaldrives
+getLogicalDrives
+  :: IO DWORD  -- ^ Bitmask of available logical drives
 getLogicalDrives =
   failIfZero "GetLogicalDrives" $ c_GetLogicalDrives
 
--- %fun GetDriveType :: Maybe String -> IO DriveType
-
-getDiskFreeSpace :: Maybe String -> IO (DWORD,DWORD,DWORD,DWORD)
+-- | Retrieves information about the amount of free and total space on a disk.
+-- Returns a tuple with (sectors per cluster, bytes per sector, number of free clusters,
+-- total number of clusters). The path argument specifies the root path of the disk
+-- (e.g., "C:\\") or Nothing for the current disk.
+--
+-- Note on atomicity:
+-- Retrieving disk free space information is atomic: the operation queries the current
+-- state of the file system and does not modify any data.
+--
+-- Possible errors:
+-- ERROR_INVALID_FUNCTION          1   (0x1)
+-- ERROR_PATH_NOT_FOUND            3   (0x3)
+-- ERROR_ACCESS_DENIED             5   (0x5)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getdiskfreespacew
+getDiskFreeSpace
+  :: Maybe String                    -- ^ Optional root path of the disk (e.g., "C:\\") or Nothing for current disk
+  -> IO (DWORD, DWORD, DWORD, DWORD) -- ^ (Sectors per cluster, bytes per sector, number of free clusters, total clusters)
 getDiskFreeSpace path =
   maybeWith withFilePath path $ \ c_path ->
   alloca $ \ p_sectors ->
@@ -536,7 +1188,28 @@ getDiskFreeSpace path =
   nclusters <- peek p_nclusters
   return (sectors, bytes, nfree, nclusters)
 
-setVolumeLabel :: Maybe String -> Maybe String -> IO ()
+-- | Sets the volume label for a disk volume.
+-- The path argument specifies the root path of the volume (e.g., "C:\\") or Nothing for the current volume.
+-- The name argument specifies the new volume label, or Nothing to delete the existing label.
+--
+-- Note on atomicity:
+-- Setting the volume label is generally atomic at the file system level. However, if a
+-- system crash or power failure occurs during the operation, the label may not be updated
+-- or may be left in an inconsistent state.
+--
+-- Possible errors:
+-- ERROR_ACCESS_DENIED             5   (0x5)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+-- ERROR_LABEL_TOO_LONG          154   (0x9A)
+-- ERROR_INVALID_NAME            123   (0x7B)
+-- ERROR_DIRECTORY               267   (0x10B)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setvolumelabelw
+setVolumeLabel
+  :: Maybe String  -- ^ Optional root path of the volume (e.g., "C:\\") or Nothing for current volume
+  -> Maybe String  -- ^ Optional new volume label, or Nothing to delete the label
+  -> IO ()
 setVolumeLabel path name =
   maybeWith withFilePath path $ \ c_path ->
   maybeWith withFilePath name $ \ c_name ->
@@ -548,6 +1221,20 @@ setVolumeLabel path name =
 
 -- | Locks a given range in a file handle, To lock an entire file
 --   use 0xFFFFFFFFFFFFFFFF for size and 0 for offset.
+--
+-- Note on atomicity:
+-- Locking a file region is atomic with respect to the lock request: the region is either
+-- locked or not, with no intermediate state. However, if a system crash or power failure
+-- occurs immediately after the lock, the state of the lock may be lost.
+--
+-- Possible errors:
+-- ERROR_INVALID_HANDLE            6   (0x6)
+-- ERROR_LOCK_VIOLATION           33   (0x21)
+-- ERROR_NOT_ENOUGH_MEMORY        8    (0x8)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex
 lockFile :: HANDLE   -- ^ CreateFile handle
          -> LockMode -- ^ Locking mode
          -> DWORD64  -- ^ Size of region to lock
@@ -564,6 +1251,19 @@ lockFile hwnd mode size f_offset =
 
 -- | Unlocks a given range in a file handle, To unlock an entire file
 --   use 0xFFFFFFFFFFFFFFFF for size and 0 for offset.
+--
+-- Note on atomicity:
+-- Unlocking a file region is atomic with respect to the unlock request: the region is
+-- either unlocked or not, with no intermediate state. However, if a system crash or
+-- power failure occurs immediately after the unlock, the state of the lock may be lost.
+--
+-- Possible errors:
+-- ERROR_INVALID_HANDLE            6   (0x6)
+-- ERROR_NOT_LOCKED              158   (0x9E)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+--
+-- Link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-unlockfileex
 unlockFile :: HANDLE  -- ^ CreateFile handle
            -> DWORD64 -- ^ Size of region to unlock
            -> DWORD64 -- ^ Beginning offset of file to unlock

--- a/System/Win32/File/Internal.hsc
+++ b/System/Win32/File/Internal.hsc
@@ -33,225 +33,541 @@ import Foreign hiding (void)
 -- Enumeration types
 ----------------------------------------------------------------
 
-type AccessMode   = UINT
+type AccessMode = UINT
 
+-- | (GENERIC_NONE = 0) No access rights.
 gENERIC_NONE :: AccessMode
 gENERIC_NONE = 0
 
-#{enum AccessMode,
- , gENERIC_READ              = GENERIC_READ
- , gENERIC_WRITE             = GENERIC_WRITE
- , gENERIC_EXECUTE           = GENERIC_EXECUTE
- , gENERIC_ALL               = GENERIC_ALL
- , dELETE                    = DELETE
- , rEAD_CONTROL              = READ_CONTROL
- , wRITE_DAC                 = WRITE_DAC
- , wRITE_OWNER               = WRITE_OWNER
- , sYNCHRONIZE               = SYNCHRONIZE
- , sTANDARD_RIGHTS_REQUIRED  = STANDARD_RIGHTS_REQUIRED
- , sTANDARD_RIGHTS_READ      = STANDARD_RIGHTS_READ
- , sTANDARD_RIGHTS_WRITE     = STANDARD_RIGHTS_WRITE
- , sTANDARD_RIGHTS_EXECUTE   = STANDARD_RIGHTS_EXECUTE
- , sTANDARD_RIGHTS_ALL       = STANDARD_RIGHTS_ALL
- , sPECIFIC_RIGHTS_ALL       = SPECIFIC_RIGHTS_ALL
- , aCCESS_SYSTEM_SECURITY    = ACCESS_SYSTEM_SECURITY
- , mAXIMUM_ALLOWED           = MAXIMUM_ALLOWED
- , fILE_ADD_FILE             = FILE_ADD_FILE
- , fILE_ADD_SUBDIRECTORY     = FILE_ADD_SUBDIRECTORY
- , fILE_ALL_ACCESS           = FILE_ALL_ACCESS
- , fILE_APPEND_DATA          = FILE_APPEND_DATA
- , fILE_CREATE_PIPE_INSTANCE = FILE_CREATE_PIPE_INSTANCE
- , fILE_DELETE_CHILD         = FILE_DELETE_CHILD
- , fILE_EXECUTE              = FILE_EXECUTE
- , fILE_LIST_DIRECTORY       = FILE_LIST_DIRECTORY
- , fILE_READ_ATTRIBUTES      = FILE_READ_ATTRIBUTES
- , fILE_READ_DATA            = FILE_READ_DATA
- , fILE_READ_EA              = FILE_READ_EA
- , fILE_TRAVERSE             = FILE_TRAVERSE
- , fILE_WRITE_ATTRIBUTES     = FILE_WRITE_ATTRIBUTES
- , fILE_WRITE_DATA           = FILE_WRITE_DATA
- , fILE_WRITE_EA             = FILE_WRITE_EA
- }
+-- | (GENERIC_READ = 0x80000000) Read access to the file or object.
+gENERIC_READ :: AccessMode
+gENERIC_READ = #const GENERIC_READ
+
+-- | (GENERIC_WRITE = 0x40000000) Write access to the file or object.
+gENERIC_WRITE :: AccessMode
+gENERIC_WRITE = #const GENERIC_WRITE
+
+-- | (GENERIC_EXECUTE = 0x20000000) Execute access to the file or object.
+gENERIC_EXECUTE :: AccessMode
+gENERIC_EXECUTE = #const GENERIC_EXECUTE
+
+-- | (GENERIC_ALL = 0x10000000) All possible access rights.
+gENERIC_ALL :: AccessMode
+gENERIC_ALL = #const GENERIC_ALL
+
+-- | (DELETE = 0x10000) Delete access.
+dELETE :: AccessMode
+dELETE = #const DELETE
+
+-- | (READ_CONTROL = 0x20000) Read access to the security descriptor and owner.
+rEAD_CONTROL :: AccessMode
+rEAD_CONTROL = #const READ_CONTROL
+
+-- | (WRITE_DAC = 0x40000) Write access to the discretionary access control list (DACL).
+wRITE_DAC :: AccessMode
+wRITE_DAC = #const WRITE_DAC
+
+-- | (WRITE_OWNER = 0x80000) Write access to the owner.
+wRITE_OWNER :: AccessMode
+wRITE_OWNER = #const WRITE_OWNER
+
+-- | (SYNCHRONIZE = 0x100000) Synchronize access.
+sYNCHRONIZE :: AccessMode
+sYNCHRONIZE = #const SYNCHRONIZE
+
+-- | (STANDARD_RIGHTS_REQUIRED = 0xF0000) Required to request all standard rights.
+sTANDARD_RIGHTS_REQUIRED :: AccessMode
+sTANDARD_RIGHTS_REQUIRED = #const STANDARD_RIGHTS_REQUIRED
+
+-- | (STANDARD_RIGHTS_READ = 0x20000) Read access to standard rights.
+sTANDARD_RIGHTS_READ :: AccessMode
+sTANDARD_RIGHTS_READ = #const STANDARD_RIGHTS_READ
+
+-- | (STANDARD_RIGHTS_WRITE = 0x20000) Write access to standard rights.
+sTANDARD_RIGHTS_WRITE :: AccessMode
+sTANDARD_RIGHTS_WRITE = #const STANDARD_RIGHTS_WRITE
+
+-- | (STANDARD_RIGHTS_EXECUTE = 0x20000) Execute access to standard rights.
+sTANDARD_RIGHTS_EXECUTE :: AccessMode
+sTANDARD_RIGHTS_EXECUTE = #const STANDARD_RIGHTS_EXECUTE
+
+-- | (STANDARD_RIGHTS_ALL = 0x1F0000) All standard rights.
+sTANDARD_RIGHTS_ALL :: AccessMode
+sTANDARD_RIGHTS_ALL = #const STANDARD_RIGHTS_ALL
+
+-- | (SPECIFIC_RIGHTS_ALL = 0xFFFF) All specific rights.
+sPECIFIC_RIGHTS_ALL :: AccessMode
+sPECIFIC_RIGHTS_ALL = #const SPECIFIC_RIGHTS_ALL
+
+-- | (ACCESS_SYSTEM_SECURITY = 0x1000000) Access to the system security ACL.
+aCCESS_SYSTEM_SECURITY :: AccessMode
+aCCESS_SYSTEM_SECURITY = #const ACCESS_SYSTEM_SECURITY
+
+-- | (MAXIMUM_ALLOWED = 0x2000000) Maximum allowed access.
+mAXIMUM_ALLOWED :: AccessMode
+mAXIMUM_ALLOWED = #const MAXIMUM_ALLOWED
+
+-- | (FILE_ADD_FILE = 0x2) Permission to add a file to a directory.
+fILE_ADD_FILE :: AccessMode
+fILE_ADD_FILE = #const FILE_ADD_FILE
+
+-- | (FILE_ADD_SUBDIRECTORY = 0x4) Permission to add a subdirectory to a directory.
+fILE_ADD_SUBDIRECTORY :: AccessMode
+fILE_ADD_SUBDIRECTORY = #const FILE_ADD_SUBDIRECTORY
+
+-- | (FILE_ALL_ACCESS = 0x1F01FF) All possible access rights for a file.
+fILE_ALL_ACCESS :: AccessMode
+fILE_ALL_ACCESS = #const FILE_ALL_ACCESS
+
+-- | (FILE_APPEND_DATA = 0x4) Permission to append data to a file.
+fILE_APPEND_DATA :: AccessMode
+fILE_APPEND_DATA = #const FILE_APPEND_DATA
+
+-- | (FILE_CREATE_PIPE_INSTANCE = 0x4) Permission to create a pipe instance.
+fILE_CREATE_PIPE_INSTANCE :: AccessMode
+fILE_CREATE_PIPE_INSTANCE = #const FILE_CREATE_PIPE_INSTANCE
+
+-- | (FILE_DELETE_CHILD = 0x40) Permission to delete a child of a directory.
+fILE_DELETE_CHILD :: AccessMode
+fILE_DELETE_CHILD = #const FILE_DELETE_CHILD
+
+-- | (FILE_EXECUTE = 0x20) Permission to execute a file.
+fILE_EXECUTE :: AccessMode
+fILE_EXECUTE = #const FILE_EXECUTE
+
+-- | (FILE_LIST_DIRECTORY = 0x1) Permission to list a directory's contents.
+fILE_LIST_DIRECTORY :: AccessMode
+fILE_LIST_DIRECTORY = #const FILE_LIST_DIRECTORY
+
+-- | (FILE_READ_ATTRIBUTES = 0x80) Permission to read file attributes.
+fILE_READ_ATTRIBUTES :: AccessMode
+fILE_READ_ATTRIBUTES = #const FILE_READ_ATTRIBUTES
+
+-- | (FILE_READ_DATA = 0x1) Permission to read file data.
+fILE_READ_DATA :: AccessMode
+fILE_READ_DATA = #const FILE_READ_DATA
+
+-- | (FILE_READ_EA = 0x8) Permission to read extended attributes.
+fILE_READ_EA :: AccessMode
+fILE_READ_EA = #const FILE_READ_EA
+
+-- | (FILE_TRAVERSE = 0x20) Permission to traverse a directory.
+fILE_TRAVERSE :: AccessMode
+fILE_TRAVERSE = #const FILE_TRAVERSE
+
+-- | (FILE_WRITE_ATTRIBUTES = 0x100) Permission to write file attributes.
+fILE_WRITE_ATTRIBUTES :: AccessMode
+fILE_WRITE_ATTRIBUTES = #const FILE_WRITE_ATTRIBUTES
+
+-- | (FILE_WRITE_DATA = 0x2) Permission to write file data.
+fILE_WRITE_DATA :: AccessMode
+fILE_WRITE_DATA = #const FILE_WRITE_DATA
+
+-- | (FILE_WRITE_EA = 0x10) Permission to write extended attributes.
+fILE_WRITE_EA :: AccessMode
+fILE_WRITE_EA = #const FILE_WRITE_EA
 
 ----------------------------------------------------------------
 
-type ShareMode   = UINT
+type ShareMode = UINT
 
+-- | (FILE_SHARE_NONE = 0) Disables sharing. No other process can open the file.
 fILE_SHARE_NONE :: ShareMode
 fILE_SHARE_NONE = 0
 
-#{enum ShareMode,
- , fILE_SHARE_READ      = FILE_SHARE_READ
- , fILE_SHARE_WRITE     = FILE_SHARE_WRITE
- , fILE_SHARE_DELETE    = FILE_SHARE_DELETE
- }
+-- | (FILE_SHARE_READ = 0x1) Enables subsequent open operations on the file to
+-- request read access.
+fILE_SHARE_READ :: ShareMode
+fILE_SHARE_READ = #const FILE_SHARE_READ
+
+-- | (FILE_SHARE_WRITE = 0x2) Enables subsequent open operations on the file to
+-- request write access.
+fILE_SHARE_WRITE :: ShareMode
+fILE_SHARE_WRITE = #const FILE_SHARE_WRITE
+
+-- | (FILE_SHARE_DELETE = 0x4) Enables subsequent open operations on the file to
+-- request delete access.
+fILE_SHARE_DELETE :: ShareMode
+fILE_SHARE_DELETE = #const FILE_SHARE_DELETE
 
 ----------------------------------------------------------------
 
-type CreateMode   = UINT
+type CreateMode = UINT
 
-#{enum CreateMode,
- , cREATE_NEW           = CREATE_NEW
- , cREATE_ALWAYS        = CREATE_ALWAYS
- , oPEN_EXISTING        = OPEN_EXISTING
- , oPEN_ALWAYS          = OPEN_ALWAYS
- , tRUNCATE_EXISTING    = TRUNCATE_EXISTING
- }
+-- | (CREATE_NEW = 1) Creates a new file. The function fails if the file already exists.
+cREATE_NEW :: CreateMode
+cREATE_NEW = #const CREATE_NEW
+
+-- | (CREATE_ALWAYS = 2) Creates a new file, always. If the file exists, it is overwritten.
+cREATE_ALWAYS :: CreateMode
+cREATE_ALWAYS = #const CREATE_ALWAYS
+
+-- | (OPEN_EXISTING = 3) Opens the file if it exists. The function fails if the file does not exist.
+oPEN_EXISTING :: CreateMode
+oPEN_EXISTING = #const OPEN_EXISTING
+
+-- | (OPEN_ALWAYS = 4) Opens the file if it exists; otherwise, creates a new file.
+oPEN_ALWAYS :: CreateMode
+oPEN_ALWAYS = #const OPEN_ALWAYS
+
+-- | (TRUNCATE_EXISTING = 5) Opens the file and truncates it to zero length. The function fails if the file does not exist.
+tRUNCATE_EXISTING :: CreateMode
+tRUNCATE_EXISTING = #const TRUNCATE_EXISTING
 
 ----------------------------------------------------------------
 
-type FileAttributeOrFlag   = UINT
+type FileAttributeOrFlag = UINT
 
-#{enum FileAttributeOrFlag,
- , fILE_ATTRIBUTE_READONLY      = FILE_ATTRIBUTE_READONLY
- , fILE_ATTRIBUTE_HIDDEN        = FILE_ATTRIBUTE_HIDDEN
- , fILE_ATTRIBUTE_SYSTEM        = FILE_ATTRIBUTE_SYSTEM
- , fILE_ATTRIBUTE_DIRECTORY     = FILE_ATTRIBUTE_DIRECTORY
- , fILE_ATTRIBUTE_ARCHIVE       = FILE_ATTRIBUTE_ARCHIVE
- , fILE_ATTRIBUTE_NORMAL        = FILE_ATTRIBUTE_NORMAL
- , fILE_ATTRIBUTE_TEMPORARY     = FILE_ATTRIBUTE_TEMPORARY
- , fILE_ATTRIBUTE_COMPRESSED    = FILE_ATTRIBUTE_COMPRESSED
- , fILE_ATTRIBUTE_REPARSE_POINT = FILE_ATTRIBUTE_REPARSE_POINT
- , fILE_FLAG_WRITE_THROUGH      = FILE_FLAG_WRITE_THROUGH
- , fILE_FLAG_OVERLAPPED         = FILE_FLAG_OVERLAPPED
- , fILE_FLAG_NO_BUFFERING       = FILE_FLAG_NO_BUFFERING
- , fILE_FLAG_RANDOM_ACCESS      = FILE_FLAG_RANDOM_ACCESS
- , fILE_FLAG_SEQUENTIAL_SCAN    = FILE_FLAG_SEQUENTIAL_SCAN
- , fILE_FLAG_DELETE_ON_CLOSE    = FILE_FLAG_DELETE_ON_CLOSE
- , fILE_FLAG_BACKUP_SEMANTICS   = FILE_FLAG_BACKUP_SEMANTICS
- , fILE_FLAG_POSIX_SEMANTICS    = FILE_FLAG_POSIX_SEMANTICS
- }
+-- | (FILE_ATTRIBUTE_READONLY = 0x1) The file is read-only.
+fILE_ATTRIBUTE_READONLY :: FileAttributeOrFlag
+fILE_ATTRIBUTE_READONLY = #const FILE_ATTRIBUTE_READONLY
+
+-- | (FILE_ATTRIBUTE_HIDDEN = 0x2) The file is hidden.
+fILE_ATTRIBUTE_HIDDEN :: FileAttributeOrFlag
+fILE_ATTRIBUTE_HIDDEN = #const FILE_ATTRIBUTE_HIDDEN
+
+-- | (FILE_ATTRIBUTE_SYSTEM = 0x4) The file is a system file.
+fILE_ATTRIBUTE_SYSTEM :: FileAttributeOrFlag
+fILE_ATTRIBUTE_SYSTEM = #const FILE_ATTRIBUTE_SYSTEM
+
+-- | (FILE_ATTRIBUTE_DIRECTORY = 0x10) The handle identifies a directory.
+fILE_ATTRIBUTE_DIRECTORY :: FileAttributeOrFlag
+fILE_ATTRIBUTE_DIRECTORY = #const FILE_ATTRIBUTE_DIRECTORY
+
+-- | (FILE_ATTRIBUTE_ARCHIVE = 0x20) The file is marked for archiving.
+fILE_ATTRIBUTE_ARCHIVE :: FileAttributeOrFlag
+fILE_ATTRIBUTE_ARCHIVE = #const FILE_ATTRIBUTE_ARCHIVE
+
+-- | (FILE_ATTRIBUTE_NORMAL = 0x80) The file has no other attributes set.
+fILE_ATTRIBUTE_NORMAL :: FileAttributeOrFlag
+fILE_ATTRIBUTE_NORMAL = #const FILE_ATTRIBUTE_NORMAL
+
+-- | (FILE_ATTRIBUTE_TEMPORARY = 0x100) The file is being used for temporary storage.
+fILE_ATTRIBUTE_TEMPORARY :: FileAttributeOrFlag
+fILE_ATTRIBUTE_TEMPORARY = #const FILE_ATTRIBUTE_TEMPORARY
+
+-- | (FILE_ATTRIBUTE_COMPRESSED = 0x800) The file or directory is compressed.
+fILE_ATTRIBUTE_COMPRESSED :: FileAttributeOrFlag
+fILE_ATTRIBUTE_COMPRESSED = #const FILE_ATTRIBUTE_COMPRESSED
+
+-- | (FILE_ATTRIBUTE_REPARSE_POINT = 0x400) The file or directory has an associated reparse point.
+fILE_ATTRIBUTE_REPARSE_POINT :: FileAttributeOrFlag
+fILE_ATTRIBUTE_REPARSE_POINT = #const FILE_ATTRIBUTE_REPARSE_POINT
+
+-- | (FILE_FLAG_WRITE_THROUGH = 0x80000000) Write operations will go directly to disk.
+fILE_FLAG_WRITE_THROUGH :: FileAttributeOrFlag
+fILE_FLAG_WRITE_THROUGH = #const FILE_FLAG_WRITE_THROUGH
+
+-- | (FILE_FLAG_OVERLAPPED = 0x40000000) The file is being opened or created for asynchronous I/O.
+fILE_FLAG_OVERLAPPED :: FileAttributeOrFlag
+fILE_FLAG_OVERLAPPED = #const FILE_FLAG_OVERLAPPED
+
+-- | (FILE_FLAG_NO_BUFFERING = 0x20000000) The file is being opened with no system buffering.
+fILE_FLAG_NO_BUFFERING :: FileAttributeOrFlag
+fILE_FLAG_NO_BUFFERING = #const FILE_FLAG_NO_BUFFERING
+
+-- | (FILE_FLAG_RANDOM_ACCESS = 0x10000000) Access is intended to be random.
+fILE_FLAG_RANDOM_ACCESS :: FileAttributeOrFlag
+fILE_FLAG_RANDOM_ACCESS = #const FILE_FLAG_RANDOM_ACCESS
+
+-- | (FILE_FLAG_SEQUENTIAL_SCAN = 0x8000000) Access is intended to be sequential from beginning to end.
+fILE_FLAG_SEQUENTIAL_SCAN :: FileAttributeOrFlag
+fILE_FLAG_SEQUENTIAL_SCAN = #const FILE_FLAG_SEQUENTIAL_SCAN
+
+-- | (FILE_FLAG_DELETE_ON_CLOSE = 0x4000000) The file is to be deleted immediately after all handles are closed.
+fILE_FLAG_DELETE_ON_CLOSE :: FileAttributeOrFlag
+fILE_FLAG_DELETE_ON_CLOSE = #const FILE_FLAG_DELETE_ON_CLOSE
+
+-- | (FILE_FLAG_BACKUP_SEMANTICS = 0x2000000) The file is being opened or created for backup or restore.
+fILE_FLAG_BACKUP_SEMANTICS :: FileAttributeOrFlag
+fILE_FLAG_BACKUP_SEMANTICS = #const FILE_FLAG_BACKUP_SEMANTICS
+
+-- | (FILE_FLAG_POSIX_SEMANTICS = 0x1000000) The file or directory is to be accessed according to POSIX rules.
+fILE_FLAG_POSIX_SEMANTICS :: FileAttributeOrFlag
+fILE_FLAG_POSIX_SEMANTICS = #const FILE_FLAG_POSIX_SEMANTICS
+
 #ifndef __WINE_WINDOWS_H
-#{enum FileAttributeOrFlag,
- , sECURITY_ANONYMOUS           = SECURITY_ANONYMOUS
- , sECURITY_IDENTIFICATION      = SECURITY_IDENTIFICATION
- , sECURITY_IMPERSONATION       = SECURITY_IMPERSONATION
- , sECURITY_DELEGATION          = SECURITY_DELEGATION
- , sECURITY_CONTEXT_TRACKING    = SECURITY_CONTEXT_TRACKING
- , sECURITY_EFFECTIVE_ONLY      = SECURITY_EFFECTIVE_ONLY
- , sECURITY_SQOS_PRESENT        = SECURITY_SQOS_PRESENT
- , sECURITY_VALID_SQOS_FLAGS    = SECURITY_VALID_SQOS_FLAGS
- }
+-- | (SECURITY_ANONYMOUS = 0x0) The security anonymous level is set.
+sECURITY_ANONYMOUS :: FileAttributeOrFlag
+sECURITY_ANONYMOUS = #const SECURITY_ANONYMOUS
+
+-- | (SECURITY_IDENTIFICATION = 0x10000) The security identification level is set.
+sECURITY_IDENTIFICATION :: FileAttributeOrFlag
+sECURITY_IDENTIFICATION = #const SECURITY_IDENTIFICATION
+
+-- | (SECURITY_IMPERSONATION = 0x20000) The security impersonation level is set.
+sECURITY_IMPERSONATION :: FileAttributeOrFlag
+sECURITY_IMPERSONATION = #const SECURITY_IMPERSONATION
+
+-- | (SECURITY_DELEGATION = 0x30000) The security delegation level is set.
+sECURITY_DELEGATION :: FileAttributeOrFlag
+sECURITY_DELEGATION = #const SECURITY_DELEGATION
+
+-- | (SECURITY_CONTEXT_TRACKING = 0x40000) Enables tracking of the security context.
+sECURITY_CONTEXT_TRACKING :: FileAttributeOrFlag
+sECURITY_CONTEXT_TRACKING = #const SECURITY_CONTEXT_TRACKING
+
+-- | (SECURITY_EFFECTIVE_ONLY = 0x80000) Only effective rights are used in access checks.
+sECURITY_EFFECTIVE_ONLY :: FileAttributeOrFlag
+sECURITY_EFFECTIVE_ONLY = #const SECURITY_EFFECTIVE_ONLY
+
+-- | (SECURITY_SQOS_PRESENT = 0x100000) The security quality of service (SQOS) is present.
+sECURITY_SQOS_PRESENT :: FileAttributeOrFlag
+sECURITY_SQOS_PRESENT = #const SECURITY_SQOS_PRESENT
+
+-- | (SECURITY_VALID_SQOS_FLAGS = 0x1F0000) All valid SQOS flags.
+sECURITY_VALID_SQOS_FLAGS :: FileAttributeOrFlag
+sECURITY_VALID_SQOS_FLAGS = #const SECURITY_VALID_SQOS_FLAGS
 #endif
 
 ----------------------------------------------------------------
 
-type MoveFileFlag   = DWORD
+type MoveFileFlag = DWORD
 
-#{enum MoveFileFlag,
- , mOVEFILE_REPLACE_EXISTING    = MOVEFILE_REPLACE_EXISTING
- , mOVEFILE_COPY_ALLOWED        = MOVEFILE_COPY_ALLOWED
- , mOVEFILE_DELAY_UNTIL_REBOOT  = MOVEFILE_DELAY_UNTIL_REBOOT
- }
+-- | (MOVEFILE_REPLACE_EXISTING = 0x1) If the destination file already
+-- exists, replace it.
+mOVEFILE_REPLACE_EXISTING :: MoveFileFlag
+mOVEFILE_REPLACE_EXISTING = #const MOVEFILE_REPLACE_EXISTING
+
+-- | (MOVEFILE_COPY_ALLOWED = 0x2) Allow the move to be performed by
+-- copying and deleting if necessary.
+mOVEFILE_COPY_ALLOWED :: MoveFileFlag
+mOVEFILE_COPY_ALLOWED = #const MOVEFILE_COPY_ALLOWED
+
+-- | (MOVEFILE_DELAY_UNTIL_REBOOT = 0x4) Delay the move operation until
+-- the system reboots.
+mOVEFILE_DELAY_UNTIL_REBOOT :: MoveFileFlag
+mOVEFILE_DELAY_UNTIL_REBOOT = #const MOVEFILE_DELAY_UNTIL_REBOOT
+
+-- | (MOVEFILE_FAIL_IF_NOT_TRACKABLE = 0x20) The move operation will fail if
+-- the system cannot track the file or directory.
+mOVEFILE_FAIL_IF_NOT_TRACKABLE :: MoveFileFlag
+mOVEFILE_FAIL_IF_NOT_TRACKABLE = #const MOVEFILE_FAIL_IF_NOT_TRACKABLE
+
+-- | (MOVEFILE_WRITE_THROUGH = 0x8) The function does not return until the file
+-- move is complete, including flushing the file buffers.
+mOVEFILE_WRITE_THROUGH :: MoveFileFlag
+mOVEFILE_WRITE_THROUGH = #const MOVEFILE_WRITE_THROUGH
+
+-- | (MOVEFILE_CREATE_HARDLINK = 0x10) The function creates a hard link at the
+-- destination instead of moving the file.
+mOVEFILE_CREATE_HARDLINK :: MoveFileFlag
+mOVEFILE_CREATE_HARDLINK = #const MOVEFILE_CREATE_HARDLINK
 
 ----------------------------------------------------------------
 
-type FilePtrDirection   = DWORD
+type FilePtrDirection = DWORD
 
-#{enum FilePtrDirection,
- , fILE_BEGIN   = FILE_BEGIN
- , fILE_CURRENT = FILE_CURRENT
- , fILE_END     = FILE_END
- }
+-- | (FILE_BEGIN = 0) The starting point is the beginning of the file.
+fILE_BEGIN :: FilePtrDirection
+fILE_BEGIN = #const FILE_BEGIN
+
+-- | (FILE_CURRENT = 1) The starting point is the current file pointer position.
+fILE_CURRENT :: FilePtrDirection
+fILE_CURRENT = #const FILE_CURRENT
+
+-- | (FILE_END = 2) The starting point is the end of the file.
+fILE_END :: FilePtrDirection
+fILE_END = #const FILE_END
 
 ----------------------------------------------------------------
 
 type DriveType = UINT
 
-#{enum DriveType,
- , dRIVE_UNKNOWN        = DRIVE_UNKNOWN
- , dRIVE_NO_ROOT_DIR    = DRIVE_NO_ROOT_DIR
- , dRIVE_REMOVABLE      = DRIVE_REMOVABLE
- , dRIVE_FIXED          = DRIVE_FIXED
- , dRIVE_REMOTE         = DRIVE_REMOTE
- , dRIVE_CDROM          = DRIVE_CDROM
- , dRIVE_RAMDISK        = DRIVE_RAMDISK
- }
+-- | (DRIVE_UNKNOWN = 0) The drive type cannot be determined.
+dRIVE_UNKNOWN :: DriveType
+dRIVE_UNKNOWN = #const DRIVE_UNKNOWN
+
+-- | (DRIVE_NO_ROOT_DIR = 1) The root path is invalid; for example, there is no
+-- volume mounted at the path.
+dRIVE_NO_ROOT_DIR :: DriveType
+dRIVE_NO_ROOT_DIR = #const DRIVE_NO_ROOT_DIR
+
+-- | (DRIVE_REMOVABLE = 2) The drive is a type that has removable media, such as
+-- a floppy drive, USB, or SD card.
+dRIVE_REMOVABLE :: DriveType
+dRIVE_REMOVABLE = #const DRIVE_REMOVABLE
+
+-- | (DRIVE_FIXED = 3) The drive is a fixed disk, such as a hard drive or SSD.
+dRIVE_FIXED :: DriveType
+dRIVE_FIXED = #const DRIVE_FIXED
+
+-- | (DRIVE_REMOTE = 4) The drive is a remote (network) drive.
+dRIVE_REMOTE :: DriveType
+dRIVE_REMOTE = #const DRIVE_REMOTE
+
+-- | (DRIVE_CDROM = 5) The drive is a CD-ROM drive.
+dRIVE_CDROM :: DriveType
+dRIVE_CDROM = #const DRIVE_CDROM
+
+-- | (DRIVE_RAMDISK = 6) The drive is a RAM disk.
+dRIVE_RAMDISK :: DriveType
+dRIVE_RAMDISK = #const DRIVE_RAMDISK
 
 ----------------------------------------------------------------
 
 type DefineDosDeviceFlags = DWORD
 
-#{enum DefineDosDeviceFlags,
- , dDD_RAW_TARGET_PATH          = DDD_RAW_TARGET_PATH
- , dDD_REMOVE_DEFINITION        = DDD_REMOVE_DEFINITION
- , dDD_EXACT_MATCH_ON_REMOVE    = DDD_EXACT_MATCH_ON_REMOVE
- }
+-- | (DDD_RAW_TARGET_PATH = 0x1) Uses the exact path specified by the target
+-- path. Otherwise, the system converts the path.
+dDD_RAW_TARGET_PATH :: DefineDosDeviceFlags
+dDD_RAW_TARGET_PATH = #const DDD_RAW_TARGET_PATH
+
+-- | (DDD_REMOVE_DEFINITION = 0x2) Removes the specified definition for the
+-- device.
+dDD_REMOVE_DEFINITION :: DefineDosDeviceFlags
+dDD_REMOVE_DEFINITION = #const DDD_REMOVE_DEFINITION
+
+-- | (DDD_EXACT_MATCH_ON_REMOVE = 0x4) Removes the device definition only if the
+-- exact match is found.
+dDD_EXACT_MATCH_ON_REMOVE :: DefineDosDeviceFlags
+dDD_EXACT_MATCH_ON_REMOVE = #const DDD_EXACT_MATCH_ON_REMOVE
 
 ----------------------------------------------------------------
 
 type BinaryType = DWORD
 
-#{enum BinaryType,
- , sCS_32BIT_BINARY     = SCS_32BIT_BINARY
- , sCS_DOS_BINARY       = SCS_DOS_BINARY
- , sCS_WOW_BINARY       = SCS_WOW_BINARY
- , sCS_PIF_BINARY       = SCS_PIF_BINARY
- , sCS_POSIX_BINARY     = SCS_POSIX_BINARY
- , sCS_OS216_BINARY     = SCS_OS216_BINARY
- }
+-- | (SCS_32BIT_BINARY = 0) Win32-based application (32-bit).
+sCS_32BIT_BINARY :: BinaryType
+sCS_32BIT_BINARY = #const SCS_32BIT_BINARY
+
+-- | (SCS_DOS_BINARY = 1) MS-DOS-based application.
+sCS_DOS_BINARY :: BinaryType
+sCS_DOS_BINARY = #const SCS_DOS_BINARY
+
+-- | (SCS_WOW_BINARY = 2) 16-bit Windows-based application.
+sCS_WOW_BINARY :: BinaryType
+sCS_WOW_BINARY = #const SCS_WOW_BINARY
+
+-- | (SCS_PIF_BINARY = 3) PIF file that executes an MS-DOS-based application.
+sCS_PIF_BINARY :: BinaryType
+sCS_PIF_BINARY = #const SCS_PIF_BINARY
+
+-- | (SCS_POSIX_BINARY = 4) POSIX-based application.
+sCS_POSIX_BINARY :: BinaryType
+sCS_POSIX_BINARY = #const SCS_POSIX_BINARY
+
+-- | (SCS_OS216_BINARY = 5) 16-bit OS/2-based application.
+sCS_OS216_BINARY :: BinaryType
+sCS_OS216_BINARY = #const SCS_OS216_BINARY
 
 ----------------------------------------------------------------
 
 type ReplaceType = DWORD
 
-#{enum ReplaceType,
- , rEPLACEFILE_WRITE_THROUGH       = REPLACEFILE_WRITE_THROUGH
- , rEPLACEFILE_IGNORE_MERGE_ERRORS = REPLACEFILE_IGNORE_MERGE_ERRORS
- , rEPLACEFILE_IGNORE_ACL_ERRORS   = REPLACEFILE_IGNORE_ACL_ERRORS
- }
+-- | (REPLACEFILE_WRITE_THROUGH = 0x1) Write through to the file system immediately.
+rEPLACEFILE_WRITE_THROUGH :: ReplaceType
+rEPLACEFILE_WRITE_THROUGH = #const REPLACEFILE_WRITE_THROUGH
+
+-- | (REPLACEFILE_IGNORE_MERGE_ERRORS = 0x2) Ignore errors that occur while
+-- merging information (such as attributes and ACLs) from the replaced file to
+-- the replacement file.
+rEPLACEFILE_IGNORE_MERGE_ERRORS :: ReplaceType
+rEPLACEFILE_IGNORE_MERGE_ERRORS = #const REPLACEFILE_IGNORE_MERGE_ERRORS
+
+-- | (REPLACEFILE_IGNORE_ACL_ERRORS = 0x4) Ignore errors that occur while
+-- merging ACL information from the replaced file to the replacement file.
+rEPLACEFILE_IGNORE_ACL_ERRORS :: ReplaceType
+rEPLACEFILE_IGNORE_ACL_ERRORS = #const REPLACEFILE_IGNORE_ACL_ERRORS
 
 ----------------------------------------------------------------
 
 type FileNotificationFlag = DWORD
 
-#{enum FileNotificationFlag,
- , fILE_NOTIFY_CHANGE_FILE_NAME  = FILE_NOTIFY_CHANGE_FILE_NAME
- , fILE_NOTIFY_CHANGE_DIR_NAME   = FILE_NOTIFY_CHANGE_DIR_NAME
- , fILE_NOTIFY_CHANGE_ATTRIBUTES = FILE_NOTIFY_CHANGE_ATTRIBUTES
- , fILE_NOTIFY_CHANGE_SIZE       = FILE_NOTIFY_CHANGE_SIZE
- , fILE_NOTIFY_CHANGE_LAST_WRITE = FILE_NOTIFY_CHANGE_LAST_WRITE
- , fILE_NOTIFY_CHANGE_SECURITY   = FILE_NOTIFY_CHANGE_SECURITY
- }
+-- | (FILE_NOTIFY_CHANGE_FILE_NAME = 0x1) Notify when a file name is changed in
+-- the watched directory.
+fILE_NOTIFY_CHANGE_FILE_NAME :: FileNotificationFlag
+fILE_NOTIFY_CHANGE_FILE_NAME = #const FILE_NOTIFY_CHANGE_FILE_NAME
+
+-- | (FILE_NOTIFY_CHANGE_DIR_NAME = 0x2) Notify when a directory name is changed
+-- in the watched directory.
+fILE_NOTIFY_CHANGE_DIR_NAME :: FileNotificationFlag
+fILE_NOTIFY_CHANGE_DIR_NAME = #const FILE_NOTIFY_CHANGE_DIR_NAME
+
+-- | (FILE_NOTIFY_CHANGE_ATTRIBUTES = 0x4) Notify when attributes of a file or
+-- directory are changed.
+fILE_NOTIFY_CHANGE_ATTRIBUTES :: FileNotificationFlag
+fILE_NOTIFY_CHANGE_ATTRIBUTES = #const FILE_NOTIFY_CHANGE_ATTRIBUTES
+
+-- | (FILE_NOTIFY_CHANGE_SIZE = 0x8) Notify when the size of a file or directory
+-- is changed.
+fILE_NOTIFY_CHANGE_SIZE :: FileNotificationFlag
+fILE_NOTIFY_CHANGE_SIZE = #const FILE_NOTIFY_CHANGE_SIZE
+
+-- | (FILE_NOTIFY_CHANGE_LAST_WRITE = 0x10) Notify when the last write time of a
+-- file or directory is changed.
+fILE_NOTIFY_CHANGE_LAST_WRITE :: FileNotificationFlag
+fILE_NOTIFY_CHANGE_LAST_WRITE = #const FILE_NOTIFY_CHANGE_LAST_WRITE
+
+-- | (FILE_NOTIFY_CHANGE_SECURITY = 0x100) Notify when the security descriptor
+-- of a file or directory is changed.
+fILE_NOTIFY_CHANGE_SECURITY :: FileNotificationFlag
+fILE_NOTIFY_CHANGE_SECURITY = #const FILE_NOTIFY_CHANGE_SECURITY
 
 ----------------------------------------------------------------
 
 type FileType = DWORD
 
-#{enum FileType,
- , fILE_TYPE_UNKNOWN    = FILE_TYPE_UNKNOWN
- , fILE_TYPE_DISK       = FILE_TYPE_DISK
- , fILE_TYPE_CHAR       = FILE_TYPE_CHAR
- , fILE_TYPE_PIPE       = FILE_TYPE_PIPE
- , fILE_TYPE_REMOTE     = FILE_TYPE_REMOTE
- }
+-- | (FILE_TYPE_UNKNOWN = 0x0000) The type of the file is unknown.
+fILE_TYPE_UNKNOWN :: FileType
+fILE_TYPE_UNKNOWN = #const FILE_TYPE_UNKNOWN
+
+-- | (FILE_TYPE_DISK = 0x0001) The file is a disk file.
+fILE_TYPE_DISK :: FileType
+fILE_TYPE_DISK = #const FILE_TYPE_DISK
+
+-- | (FILE_TYPE_CHAR = 0x0002) The file is a character file, typically an LPT
+-- device or a console.
+fILE_TYPE_CHAR :: FileType
+fILE_TYPE_CHAR = #const FILE_TYPE_CHAR
+
+-- | (FILE_TYPE_PIPE = 0x0003) The file is a pipe or named pipe.
+fILE_TYPE_PIPE :: FileType
+fILE_TYPE_PIPE = #const FILE_TYPE_PIPE
+
+-- | (FILE_TYPE_REMOTE = 0x8000) The file is a remote file.
+fILE_TYPE_REMOTE :: FileType
+fILE_TYPE_REMOTE = #const FILE_TYPE_REMOTE
 
 ----------------------------------------------------------------
 
 type LockMode = DWORD
 
-#{enum LockMode,
- , lOCKFILE_EXCLUSIVE_LOCK   = LOCKFILE_EXCLUSIVE_LOCK
- , lOCKFILE_FAIL_IMMEDIATELY = LOCKFILE_FAIL_IMMEDIATELY
- }
+-- | (LOCKFILE_EXCLUSIVE_LOCK = 0x2) Locks the specified region of the file
+-- exclusively. No other process can access the locked region.
+lOCKFILE_EXCLUSIVE_LOCK :: LockMode
+lOCKFILE_EXCLUSIVE_LOCK = #const LOCKFILE_EXCLUSIVE_LOCK
+
+-- | (LOCKFILE_FAIL_IMMEDIATELY = 0x1) Fails immediately if the lock cannot be
+-- acquired.
+lOCKFILE_FAIL_IMMEDIATELY :: LockMode
+lOCKFILE_FAIL_IMMEDIATELY = #const LOCKFILE_FAIL_IMMEDIATELY
 
 ----------------------------------------------------------------
 
+-- | GET_FILEEX_INFO_LEVELS is used to specify the type of information to retrieve
+-- in functions like GetFileAttributesExW. (for example, it may be Int on
+-- 32-bit systems and DWORD on 64-bit systems, or as defined in the Windows SDK)
 newtype GET_FILEEX_INFO_LEVELS = GET_FILEEX_INFO_LEVELS (#type GET_FILEEX_INFO_LEVELS)
     deriving (Eq, Ord)
 
-#{enum GET_FILEEX_INFO_LEVELS, GET_FILEEX_INFO_LEVELS
- , getFileExInfoStandard = GetFileExInfoStandard
- , getFileExMaxInfoLevel = GetFileExMaxInfoLevel
- }
+-- | (GetFileExInfoStandard = 0) Retrieves the standard set of file attribute
+-- information. The lpFileInformation parameter must point to a
+-- WIN32_FILE_ATTRIBUTE_DATA structure.
+getFileExInfoStandard :: GET_FILEEX_INFO_LEVELS
+getFileExInfoStandard = GET_FILEEX_INFO_LEVELS $ #const GetFileExInfoStandard
+
+-- | (GetFileExMaxInfoLevel = 1) Reserved for future use.
+getFileExMaxInfoLevel :: GET_FILEEX_INFO_LEVELS
+getFileExMaxInfoLevel = GET_FILEEX_INFO_LEVELS $ #const GetFileExMaxInfoLevel
 
 ----------------------------------------------------------------
 
 data SECURITY_ATTRIBUTES = SECURITY_ATTRIBUTES
-    { nLength              :: !DWORD
-    , lpSecurityDescriptor :: !LPVOID
-    , bInheritHandle       :: !BOOL
-    } deriving Show
+  { nLength              :: !DWORD   -- ^ The size, in bytes, of this structure.
+  , lpSecurityDescriptor :: !LPVOID  -- ^ A pointer to a security descriptor for the object.
+  , bInheritHandle       :: !BOOL    -- ^ Specifies whether the returned handle is inheritable.
+  } deriving (Show)
 
 type PSECURITY_ATTRIBUTES = Ptr SECURITY_ATTRIBUTES
 type LPSECURITY_ATTRIBUTES = Ptr SECURITY_ATTRIBUTES
@@ -275,13 +591,15 @@ instance Storable SECURITY_ATTRIBUTES where
 ----------------------------------------------------------------
 
 data BY_HANDLE_FILE_INFORMATION = BY_HANDLE_FILE_INFORMATION
-    { bhfiFileAttributes :: FileAttributeOrFlag
-    , bhfiCreationTime, bhfiLastAccessTime, bhfiLastWriteTime :: FILETIME
-    , bhfiVolumeSerialNumber :: DWORD
-    , bhfiSize :: DDWORD
-    , bhfiNumberOfLinks :: DWORD
-    , bhfiFileIndex :: DDWORD
-    } deriving (Show)
+  { bhfiFileAttributes     :: !FileAttributeOrFlag -- ^ File attributes.
+  , bhfiCreationTime       :: !FILETIME            -- ^ Time the file was created.
+  , bhfiLastAccessTime     :: !FILETIME            -- ^ Time the file was last accessed.
+  , bhfiLastWriteTime      :: !FILETIME            -- ^ Time the file was last written to.
+  , bhfiVolumeSerialNumber :: !DWORD               -- ^ Serial number of the volume that contains the file.
+  , bhfiSize               :: !DDWORD              -- ^ File size, in bytes.
+  , bhfiNumberOfLinks      :: !DWORD               -- ^ Number of hard links to the file.
+  , bhfiFileIndex          :: !DDWORD              -- ^ Unique identifier for the file within the volume.
+  } deriving (Show)
 
 instance Storable BY_HANDLE_FILE_INFORMATION where
     sizeOf = const (#size BY_HANDLE_FILE_INFORMATION)
@@ -318,10 +636,12 @@ instance Storable BY_HANDLE_FILE_INFORMATION where
 ----------------------------------------------------------------
 
 data WIN32_FILE_ATTRIBUTE_DATA = WIN32_FILE_ATTRIBUTE_DATA
-    { fadFileAttributes :: DWORD
-    , fadCreationTime , fadLastAccessTime , fadLastWriteTime :: FILETIME
-    , fadFileSize :: DDWORD
-    } deriving (Show)
+  { fadFileAttributes :: !DWORD     -- ^ File attributes.
+  , fadCreationTime   :: !FILETIME  -- ^ Time the file was created.
+  , fadLastAccessTime :: !FILETIME  -- ^ Time the file was last accessed.
+  , fadLastWriteTime  :: !FILETIME  -- ^ Time the file was last written to.
+  , fadFileSize       :: !DDWORD    -- ^ File size, in bytes.
+  } deriving (Show)
 
 instance Storable WIN32_FILE_ATTRIBUTE_DATA where
     sizeOf = const (#size WIN32_FILE_ATTRIBUTE_DATA)
@@ -350,33 +670,315 @@ instance Storable WIN32_FILE_ATTRIBUTE_DATA where
 -- File operations
 ----------------------------------------------------------------
 
+-- | Deletes an existing file.
+--------------------------------------------------------------------------------
+-- Deletes the specified file. If the file is open or in use, the function fails.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] lpFileName
+-- The name of the file to be deleted.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_SHARING_VIOLATION  32  (0x20)
+-- The file is being used by another process.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-deletefilew
 foreign import WINDOWS_CCONV unsafe "windows.h DeleteFileW"
   c_DeleteFile :: LPCTSTR -> IO Bool
 
+-- | Copies an existing file to a new file.
+--------------------------------------------------------------------------------
+-- Copies an existing file to a new file. The copy fails if the destination file
+-- already exists, unless the failIfExists parameter is set to FALSE.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] lpExistingFileName
+-- The name of an existing file.
+--------------------------------------------------------------------------------
+-- [in] lpNewFileName
+-- The name of the new file.
+--------------------------------------------------------------------------------
+-- [in] bFailIfExists
+-- If this parameter is TRUE and the new file specified by lpNewFileName already
+-- exists, the function fails. If this parameter is FALSE and the new file
+-- already exists, the function overwrites the existing file and succeeds.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_FILE_EXISTS        80  (0x50)
+-- The destination file already exists and bFailIfExists is TRUE.
+--
+-- ERROR_SHARING_VIOLATION  32  (0x20)
+-- The file is being used by another process.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-copyfilew
 foreign import WINDOWS_CCONV unsafe "windows.h CopyFileW"
   c_CopyFile :: LPCTSTR -> LPCTSTR -> Bool -> IO Bool
 
+-- | Moves an existing file or directory to a new location.
+--------------------------------------------------------------------------------
+-- Moves an existing file or directory to a new location. The move fails if the
+-- destination already exists.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] lpExistingFileName
+-- The current name of the file or directory.
+--------------------------------------------------------------------------------
+-- [in] lpNewFileName
+-- The new name for the file or directory.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_ALREADY_EXISTS      183 (0xB7)
+-- The destination already exists and cannot be replaced.
+--
+-- ERROR_SHARING_VIOLATION   32 (0x20)
+-- The file is being used by another process.
+--
+-- ERROR_NOT_SAME_DEVICE     17 (0x11)
+-- The file cannot be moved to a different disk drive.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefilew
 foreign import WINDOWS_CCONV unsafe "windows.h MoveFileW"
   c_MoveFile :: LPCTSTR -> LPCTSTR -> IO Bool
 
+-- | Moves an existing file or directory, including its children.
+--------------------------------------------------------------------------------
+-- Moves an existing file or directory to a new location, with the option to
+-- replace the destination file or directory if it already exists.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] lpExistingFileName
+-- The current name of the file or directory.
+--------------------------------------------------------------------------------
+-- [in] lpNewFileName
+-- The new name for the file or directory.
+--------------------------------------------------------------------------------
+-- [in] dwFlags
+-- Move options. This parameter can be one or more of the following values:
+--   MOVEFILE_REPLACE_EXISTING    0x00000001
+--   MOVEFILE_COPY_ALLOWED        0x00000002
+--   MOVEFILE_DELAY_UNTIL_REBOOT  0x00000004
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_ALREADY_EXISTS      183 (0xB7)
+-- The destination already exists and cannot be replaced.
+--
+-- ERROR_SHARING_VIOLATION   32 (0x20)
+-- The file is being used by another process.
+--
+-- ERROR_NOT_SAME_DEVICE     17 (0x11)
+-- The file cannot be moved to a different disk drive.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexw
 foreign import WINDOWS_CCONV unsafe "windows.h MoveFileExW"
   c_MoveFileEx :: LPCTSTR -> LPCTSTR -> MoveFileFlag -> IO Bool
 
+-- | Changes the current directory for the current process.
+--------------------------------------------------------------------------------
+-- Sets the current directory for the current process to the specified path.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] lpPathName
+-- The path to the new current directory.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+-- Or returns common errors.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setcurrentdirectory
 foreign import WINDOWS_CCONV unsafe "windows.h SetCurrentDirectoryW"
   c_SetCurrentDirectory :: LPCTSTR -> IO Bool
 
+-- | Creates a new directory.
+--------------------------------------------------------------------------------
+-- Creates a new directory with the specified name. The security descriptor of
+-- the new directory can be specified.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] lpPathName
+-- The path of the directory to be created.
+--------------------------------------------------------------------------------
+-- [in, optional] lpSecurityAttributes
+-- A pointer to a SECURITY_ATTRIBUTES structure that determines whether the
+-- returned handle can be inherited by child processes. Can be NULL.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_ALREADY_EXISTS   183 (0xB7)
+-- The directory already exists.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createdirectoryw
 foreign import WINDOWS_CCONV unsafe "windows.h CreateDirectoryW"
   c_CreateDirectory :: LPCTSTR -> LPSECURITY_ATTRIBUTES -> IO Bool
 
+-- | Creates a directory as a copy of an existing directory.
+--------------------------------------------------------------------------------
+-- Creates a new directory with the attributes and security descriptor of an existing directory.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] lpTemplateDirectory
+-- The path of an existing directory whose attributes and security descriptor
+-- are to be copied to the new directory.
+--------------------------------------------------------------------------------
+-- [in] lpNewDirectory
+-- The path of the directory to be created.
+--------------------------------------------------------------------------------
+-- [in, optional] lpSecurityAttributes
+-- A pointer to a SECURITY_ATTRIBUTES structure that determines whether the
+-- returned handle can be inherited by child processes. Can be NULL.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_ALREADY_EXISTS   183 (0xB7)
+-- The directory already exists.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createdirectoryexw
 foreign import WINDOWS_CCONV unsafe "windows.h CreateDirectoryExW"
   c_CreateDirectoryEx :: LPCTSTR -> LPCTSTR -> LPSECURITY_ATTRIBUTES -> IO Bool
 
+-- | Removes (deletes) an existing empty directory.
+--------------------------------------------------------------------------------
+-- Deletes the specified empty directory. If the directory is not empty or is in use,
+-- the function fails.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] lpPathName
+-- The path of the directory to be removed. The path must specify an empty directory,
+-- and the calling process must have delete access to the directory.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_DIR_NOT_EMPTY      145 (0x91)
+-- The directory is not empty.
+--
+-- ERROR_SHARING_VIOLATION  32  (0x20)
+-- The directory is being used by another process.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-removedirectoryw
 foreign import WINDOWS_CCONV unsafe "windows.h RemoveDirectoryW"
   c_RemoveDirectory :: LPCTSTR -> IO Bool
 
+-- | Determines the type of a binary executable file.
+--------------------------------------------------------------------------------
+-- Determines whether a file is executable, and if so, what type of executable
+-- it is (e.g., console application, Windows application, etc.).
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] lpApplicationName
+-- The full path of the binary executable file for which to determine the type.
+--------------------------------------------------------------------------------
+-- [out] lpBinaryType
+-- A pointer to a variable that receives the binary type. This parameter can
+-- be one of the following values:
+--
+-- SCS_32BIT_BINARY 0 (32-bit Windows-based application)
+-- SCS_64BIT_BINARY 6 (64-bit Windows-based application)
+-- SCS_DOS_BINARY   1 (MS-DOS-based application)
+-- SCS_OS216_BINARY 5 (16-bit OS/2-based application) (not supported on 64-bit Windows)
+-- SCS_PIF_BINARY   3 (PIF file that executes an MS-DOS-based application)
+-- SCS_POSIX_BINARY 4 (POSIX-based application)
+-- SCS_WOW_BINARY   2 (16-bit Windows-based application)
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_BAD_EXE_FORMAT    193 (0xC1)
+-- The specified file is not a valid executable file.
+--
+-- ERROR_INVALID_PARAMETER 87  (0x57)
+-- The lpBinaryType parameter is NULL or the specified file is not a valid executable file.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getbinarytypew
 foreign import WINDOWS_CCONV unsafe "windows.h GetBinaryTypeW"
   c_GetBinaryType :: LPCTSTR -> Ptr DWORD -> IO Bool
 
+-- | Replaces one file with another file.
+--------------------------------------------------------------------------------
+-- Replaces one file with another file, with the option of creating a backup
+-- copy of the original file. The replacement file assumes the name of the
+-- replaced file and its identity.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] lpReplacedFileName
+-- The name of the file to be replaced.
+--------------------------------------------------------------------------------
+-- [in] lpReplacementFileName
+-- The name of the file that will replace the lpReplacedFileName file.
+--------------------------------------------------------------------------------
+-- [in, optional] lpBackupFileName
+-- The name of the file that will serve as a backup copy of the lpReplacedFileName file.
+--------------------------------------------------------------------------------
+-- [in] dwReplaceFlags
+-- The replacement options. This parameter can be one or more of the following values.
+-- 
+-- REPLACEFILE_WRITE_THROUGH 0x00000001
+-- This value is not supported.
+-- 
+-- REPLACEFILE_IGNORE_MERGE_ERRORS 0x00000002
+-- Ignores errors that occur while merging information.
+--
+-- REPLACEFILE_IGNORE_ACL_ERRORS 0x00000004
+-- Ignores errors that occur while merging ACL information.
+--------------------------------------------------------------------------------
+-- lpExclude
+-- Reserved for future use.
+--------------------------------------------------------------------------------
+-- lpReserved
+-- Reserved for future use.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_UNABLE_TO_MOVE_REPLACEMENT   1176 (0x498)
+-- The replacement file could not be renamed.
+--
+-- ERROR_UNABLE_TO_MOVE_REPLACEMENT_2 1177 (0x499)
+-- The replacement file could not be moved.
+--
+-- ERROR_UNABLE_TO_REMOVE_REPLACED    1175 (0x497)
+-- The replaced file could not be deleted.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-replacefilew
 foreign import WINDOWS_CCONV unsafe "windows.h ReplaceFileW"
   c_ReplaceFile :: LPCWSTR -> LPCWSTR -> LPCWSTR -> DWORD -> LPVOID -> LPVOID -> IO Bool
 
@@ -384,34 +986,266 @@ foreign import WINDOWS_CCONV unsafe "windows.h ReplaceFileW"
 -- HANDLE operations
 ----------------------------------------------------------------
 
+-- | Creates or opens a file or I/O device.
+--------------------------------------------------------------------------------
+-- Creates or opens a file, directory, physical disk, volume, console buffer,
+-- tape drive, communications resource, or other I/O device.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] lpFileName
+-- The name of the file or device to be created or opened.
+--------------------------------------------------------------------------------
+-- [in] dwDesiredAccess
+-- The requested access to the file or device (see AccessMode).
+--------------------------------------------------------------------------------
+-- [in] dwShareMode
+-- The requested sharing mode of the file or device (see ShareMode).
+--------------------------------------------------------------------------------
+-- [in, optional] lpSecurityAttributes
+-- A pointer to a SECURITY_ATTRIBUTES structure that determines whether the
+-- returned handle can be inherited by child processes. Can be NULL.
+--------------------------------------------------------------------------------
+-- [in] dwCreationDisposition
+-- An action to take on files that exist or do not exist (see CreateMode).
+--------------------------------------------------------------------------------
+-- [in] dwFlagsAndAttributes
+-- The file or device attributes and flags (see FileAttributeOrFlag).
+--------------------------------------------------------------------------------
+-- [in, optional] hTemplateFile
+-- A valid handle to a template file with the GENERIC_READ access right.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is an open handle to the specified
+-- file, device, or I/O resource.
+-- If the function fails, the return value is INVALID_HANDLE_VALUE.
+--
+-- ERROR_ALREADY_EXISTS    183   (0xB7)
+-- The file already exists and cannot be created.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew
 foreign import WINDOWS_CCONV unsafe "windows.h CreateFileW"
-  c_CreateFile :: LPCTSTR -> AccessMode -> ShareMode -> LPSECURITY_ATTRIBUTES -> CreateMode -> FileAttributeOrFlag -> HANDLE -> IO HANDLE
+  c_CreateFile :: LPCTSTR -> AccessMode -> ShareMode -> LPSECURITY_ATTRIBUTES
+               -> CreateMode -> FileAttributeOrFlag -> HANDLE -> IO HANDLE
 
+-- | Closes an open object handle.
+--------------------------------------------------------------------------------
+-- Closes an open handle to an object, such as a file, process, thread, or
+-- registry key.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] hObject
+-- A valid handle to an open object.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_INVALID_HANDLE    6   (0x6)
+-- The handle is invalid.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-closehandle
 foreign import WINDOWS_CCONV unsafe "windows.h CloseHandle"
   c_CloseHandle :: HANDLE -> IO Bool
 
+-- | Retrieves the file type of the specified file.
+--------------------------------------------------------------------------------
+-- Determines the type of a file (disk file, character file, pipe, etc.) based
+-- on the specified file handle.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] hFile
+-- A handle to the file whose type is to be determined.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value indicates the FileType.
+-- If the function fails, the return value is FILE_TYPE_UNKNOWN.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfiletype
 foreign import WINDOWS_CCONV unsafe "windows.h GetFileType"
   getFileType :: HANDLE -> IO FileType
---Apparently no error code
 
+-- | Flushes the buffers of a specified file and causes all buffered data to be written to disk.
+--------------------------------------------------------------------------------
+-- Writes all buffered data for the specified file to disk. This ensures that
+-- all data written to the file so far is physically stored on the disk device.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] hFile
+-- A handle to the open file whose buffers are to be flushed. The handle must
+-- have write access.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_INVALID_HANDLE    6   (0x6)
+-- The handle is invalid.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-flushfilebuffers
 foreign import WINDOWS_CCONV unsafe "windows.h FlushFileBuffers"
   c_FlushFileBuffers :: HANDLE -> IO Bool
 
+-- | Sets the physical end of a file.
+--------------------------------------------------------------------------------
+-- Moves the end-of-file (EOF) position for the specified file to the current
+-- position of the file pointer. This function can be used to truncate or extend
+-- a file.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] hFile
+-- A handle to the file. The file handle must have GENERIC_WRITE access.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_INVALID_HANDLE    6   (0x6)
+-- The handle is invalid.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setendoffile
 foreign import WINDOWS_CCONV unsafe "windows.h SetEndOfFile"
   c_SetEndOfFile :: HANDLE -> IO Bool
 
+-- | Sets the attributes for a file or directory.
+--------------------------------------------------------------------------------
+-- Sets the file system attributes for a specified file or directory.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] lpFileName
+-- The name of the file or directory whose attributes are to be set.
+--------------------------------------------------------------------------------
+-- [in] dwFileAttributes
+-- The file attributes to set for the file or directory. This parameter can be
+-- a combination of FileAttributeOrFlag values.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_INVALID_PARAMETER   87  (0x57)
+-- One or more parameters are invalid.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfileattributesw
 foreign import WINDOWS_CCONV unsafe "windows.h SetFileAttributesW"
   c_SetFileAttributes :: LPCTSTR -> FileAttributeOrFlag -> IO Bool
 
+-- | Retrieves file system attributes for a specified file or directory.
+--------------------------------------------------------------------------------
+-- Retrieves attribute information for a specified file or directory.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] lpFileName
+-- The name of the file or directory.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is the attributes of the file or directory.
+-- If the function fails, the return value is INVALID_FILE_ATTRIBUTES.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfileattributesw
 foreign import WINDOWS_CCONV unsafe "windows.h GetFileAttributesW"
   c_GetFileAttributes :: LPCTSTR -> IO FileAttributeOrFlag
 
+-- | Retrieves extended information about the specified file or directory.
+--------------------------------------------------------------------------------
+-- Retrieves attributes for a specified file or directory, including times and
+-- file size, and stores them in a WIN32_FILE_ATTRIBUTE_DATA structure.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] lpFileName
+-- The name of the file or directory.
+--------------------------------------------------------------------------------
+-- [in] fInfoLevelId
+-- The information level to retrieve. Must be GetFileExInfoStandard.
+--------------------------------------------------------------------------------
+-- [out] lpFileInformation
+-- A pointer to a buffer that receives the attribute data (typically a
+-- WIN32_FILE_ATTRIBUTE_DATA structure).
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_INVALID_PARAMETER   87  (0x57)
+-- One or more parameters are invalid.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfileattributesexw
 foreign import WINDOWS_CCONV unsafe "windows.h GetFileAttributesExW"
   c_GetFileAttributesEx :: LPCTSTR -> GET_FILEEX_INFO_LEVELS -> Ptr a -> IO BOOL
 
+-- | Retrieves file information for the specified file.
+--------------------------------------------------------------------------------
+-- Retrieves information about a file based on the file handle. The information
+-- includes attributes, times, size, and more.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] hFile
+-- A handle to the file for which information is to be retrieved.
+--------------------------------------------------------------------------------
+-- [out] lpFileInformation
+-- A pointer to a BY_HANDLE_FILE_INFORMATION structure that receives the file
+-- information.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+-- Or returns common errors.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfileinformationbyhandle
 foreign import WINDOWS_CCONV unsafe "windows.h GetFileInformationByHandle"
     c_GetFileInformationByHandle :: HANDLE -> Ptr BY_HANDLE_FILE_INFORMATION -> IO BOOL
 
+-- | Creates a name for a temporary file and optionally creates the file.
+--------------------------------------------------------------------------------
+-- Generates a unique temporary file name, and optionally creates the file in
+-- the specified directory.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] lpPathName
+-- The directory in which the temporary file will be created.
+--------------------------------------------------------------------------------
+-- [in] lpPrefixString
+-- The prefix of the temporary file name. The function uses the first three
+-- characters of this string as the prefix.
+--------------------------------------------------------------------------------
+-- [in] uUnique
+-- If this parameter is zero, the function creates the file. If it is nonzero,
+-- the function only generates a unique file name.
+--------------------------------------------------------------------------------
+-- [out] lpTempFileName
+-- A buffer that receives the temporary file name.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is the length, in characters, of
+-- the string copied to lpTempFileName, not including the terminating null
+-- character.
+--
+-- ERROR_BUFFER_OVERFLOW   111 (0x6F)
+-- The buffer is too small to hold the generated file name.
+--
+-- ERROR_DIRECTORY         267 (0x10B)
+-- The specified path is invalid.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettempfilenamew
 foreign import WINDOWS_CCONV unsafe "windows.h GetTempFileNameW"
     c_GetTempFileNameW :: LPCWSTR -> LPCWSTR -> UINT -> LPWSTR -> IO UINT
 
@@ -420,13 +1254,13 @@ foreign import WINDOWS_CCONV unsafe "windows.h GetTempFileNameW"
 ----------------------------------------------------------------
 
 -- No support for this yet
-data OVERLAPPED
-  = OVERLAPPED { ovl_internal     :: ULONG_PTR
-               , ovl_internalHigh :: ULONG_PTR
-               , ovl_offset       :: DWORD
-               , ovl_offsetHigh   :: DWORD
-               , ovl_hEvent       :: HANDLE
-               } deriving (Show)
+data OVERLAPPED = OVERLAPPED
+  { ovl_internal     :: !ULONG_PTR -- ^ Reserved for operating system use.
+  , ovl_internalHigh :: !ULONG_PTR -- ^ Reserved for operating system use.
+  , ovl_offset       :: !DWORD     -- ^ Low-order part of the file position at which to start the I/O operation.
+  , ovl_offsetHigh   :: !DWORD     -- ^ High-order part of the file position at which to start the I/O operation.
+  , ovl_hEvent       :: !HANDLE    -- ^ Handle to an event that will be set to the signaled state when the operation has been completed.
+  } deriving (Show)
 
 instance Storable OVERLAPPED where
   sizeOf = const (#size OVERLAPPED)
@@ -450,12 +1284,102 @@ type LPOVERLAPPED = Ptr OVERLAPPED
 
 type MbLPOVERLAPPED = Maybe LPOVERLAPPED
 
+-- | Reads data from a file or input/output (I/O) device.
+--------------------------------------------------------------------------------
+-- Reads data from the specified file or input/output device into a buffer.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] hFile
+-- A handle to the file or I/O device to be read.
+--------------------------------------------------------------------------------
+-- [out] lpBuffer
+-- A pointer to the buffer that receives the data read from the file or device.
+--------------------------------------------------------------------------------
+-- [in] nNumberOfBytesToRead
+-- The maximum number of bytes to be read.
+--------------------------------------------------------------------------------
+-- [out, optional] lpNumberOfBytesRead
+-- A pointer to the variable that receives the number of bytes read.
+--------------------------------------------------------------------------------
+-- [in, optional] lpOverlapped
+-- A pointer to an OVERLAPPED structure for asynchronous operations. Can be NULL
+-- for synchronous operations.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_IO_PENDING        997 (0x3E5)
+-- An overlapped I/O operation is in progress.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-readfile
 foreign import WINDOWS_CCONV unsafe "windows.h ReadFile"
   c_ReadFile :: HANDLE -> Ptr a -> DWORD -> Ptr DWORD -> LPOVERLAPPED -> IO Bool
 
+-- | Writes data to a file or input/output (I/O) device.
+--------------------------------------------------------------------------------
+-- Writes data from a buffer to the specified file or input/output device.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] hFile
+-- A handle to the file or I/O device to be written to.
+--------------------------------------------------------------------------------
+-- [in] lpBuffer
+-- A pointer to the buffer containing the data to be written.
+--------------------------------------------------------------------------------
+-- [in] nNumberOfBytesToWrite
+-- The number of bytes to be written.
+--------------------------------------------------------------------------------
+-- [out, optional] lpNumberOfBytesWritten
+-- A pointer to the variable that receives the number of bytes written.
+--------------------------------------------------------------------------------
+-- [in, optional] lpOverlapped
+-- A pointer to an OVERLAPPED structure for asynchronous operations. Can be NULL
+-- for synchronous operations.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_IO_PENDING        997 (0x3E5)
+-- An overlapped I/O operation is in progress.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-writefile
 foreign import WINDOWS_CCONV unsafe "windows.h WriteFile"
   c_WriteFile :: HANDLE -> Ptr a -> DWORD -> Ptr DWORD -> LPOVERLAPPED -> IO Bool
 
+-- | Moves the file pointer of an open file.
+--------------------------------------------------------------------------------
+-- Sets the file pointer for the specified file to a new position, which can be
+-- specified as an offset from the beginning, current position, or end of the file.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] hFile
+-- A handle to the file whose file pointer is to be moved.
+--------------------------------------------------------------------------------
+-- [in] liDistanceToMove
+-- The number of bytes to move the file pointer.
+--------------------------------------------------------------------------------
+-- [out, optional] lpNewFilePointer
+-- A pointer to a variable that receives the new file pointer value. Can be NULL.
+--------------------------------------------------------------------------------
+-- [in] dwMoveMethod
+-- The starting point for the file pointer move (see FilePtrDirection).
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_INVALID_PARAMETER 87  (0x57)
+-- One or more parameters are invalid.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfilepointerex
 foreign import WINDOWS_CCONV unsafe "windows.h SetFilePointerEx"
   c_SetFilePointerEx :: HANDLE -> LARGE_INTEGER -> Ptr LARGE_INTEGER -> FilePtrDirection -> IO Bool
 
@@ -466,12 +1390,78 @@ foreign import WINDOWS_CCONV unsafe "windows.h SetFilePointerEx"
 -- on.
 ----------------------------------------------------------------
 
+-- | Creates a change notification handle and sets up initial change notification filter conditions.
+--------------------------------------------------------------------------------
+-- Creates a handle that can be used to monitor a directory or subtree for
+-- changes such as file creation, deletion, or modification.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] lpPathName
+-- The path of the directory to be monitored.
+--------------------------------------------------------------------------------
+-- [in] bWatchSubtree
+-- If TRUE, the function monitors the directory tree rooted at the specified
+-- directory; if FALSE, it monitors only the specified directory.
+--------------------------------------------------------------------------------
+-- [in] dwNotifyFilter
+-- The filter conditions that satisfy a change notification wait. This parameter
+-- can be one or more FileNotificationFlag values.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is a handle to the change
+-- notification object. If the function fails, the return value is
+-- INVALID_HANDLE_VALUE.
+--
+-- ERROR_INVALID_PARAMETER   87  (0x57)
+-- One or more parameters are invalid.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstchangenotificationw
 foreign import WINDOWS_CCONV unsafe "windows.h FindFirstChangeNotificationW"
   c_FindFirstChangeNotification :: LPCTSTR -> Bool -> FileNotificationFlag -> IO HANDLE
 
+-- | Requests that the operating system signal a change notification handle when a change occurs.
+--------------------------------------------------------------------------------
+-- Continues monitoring a directory or subtree for changes after a previous
+-- change notification has been received.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] hChangeHandle
+-- A handle to a change notification object returned by FindFirstChangeNotificationW.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_INVALID_HANDLE    6   (0x6)
+-- The handle is invalid.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findnextchangenotification
 foreign import WINDOWS_CCONV unsafe "windows.h FindNextChangeNotification"
   c_FindNextChangeNotification :: HANDLE -> IO Bool
 
+-- | Closes a change notification handle.
+--------------------------------------------------------------------------------
+-- Closes a handle created by FindFirstChangeNotificationW and releases any
+-- associated resources.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] hChangeHandle
+-- A handle to a change notification object returned by FindFirstChangeNotificationW.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_INVALID_HANDLE    6   (0x6)
+-- The handle is invalid.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findclosechangenotification
 foreign import WINDOWS_CCONV unsafe "windows.h FindCloseChangeNotification"
   c_FindCloseChangeNotification :: HANDLE -> IO Bool
 
@@ -483,12 +1473,77 @@ type WIN32_FIND_DATA = ()
 
 newtype FindData = FindData (ForeignPtr WIN32_FIND_DATA)
 
+-- | Searches a directory for a file or subdirectory with a name that matches a specified pattern.
+--------------------------------------------------------------------------------
+-- Begins a file search in a directory, returning information about the first
+-- file or subdirectory found that matches the specified pattern.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] lpFileName
+-- The directory or path, and the file name, which can include wildcard
+-- characters (* and ?).
+--------------------------------------------------------------------------------
+-- [out] lpFindFileData
+-- A pointer to a WIN32_FIND_DATA structure that receives information about the
+-- found file or directory.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is a search handle used in
+-- subsequent calls to FindNextFile or FindClose. If the function fails, the
+-- return value is INVALID_HANDLE_VALUE.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstfilew
 foreign import WINDOWS_CCONV unsafe "windows.h FindFirstFileW"
   c_FindFirstFile :: LPCTSTR -> Ptr WIN32_FIND_DATA -> IO HANDLE
 
+-- | Continues a file search from a previous call to FindFirstFileW.
+--------------------------------------------------------------------------------
+-- Retrieves information about the next file or directory that matches the
+-- search criteria specified in a previous call to FindFirstFileW.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] hFindFile
+-- The search handle returned by a previous call to FindFirstFileW.
+--------------------------------------------------------------------------------
+-- [out] lpFindFileData
+-- A pointer to a WIN32_FIND_DATA structure that receives information about the
+-- found file or directory.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero, and no more files are found
+-- or an error occurred.
+--
+-- ERROR_NO_MORE_FILES      18  (0x12)
+-- No more files were found.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findnextfilew
 foreign import WINDOWS_CCONV unsafe "windows.h FindNextFileW"
   c_FindNextFile :: HANDLE -> Ptr WIN32_FIND_DATA -> IO BOOL
 
+-- | Closes a file search handle.
+--------------------------------------------------------------------------------
+-- Closes a search handle opened by FindFirstFileW or FindNextFileW and releases
+-- any associated resources.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] hFindFile
+-- The search handle returned by FindFirstFileW.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_INVALID_HANDLE    6   (0x6)
+-- The handle is invalid.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findclose
 foreign import WINDOWS_CCONV unsafe "windows.h FindClose"
   c_FindClose :: HANDLE -> IO BOOL
 
@@ -496,6 +1551,32 @@ foreign import WINDOWS_CCONV unsafe "windows.h FindClose"
 -- DOS Device flags
 ----------------------------------------------------------------
 
+-- | Defines, modifies, or deletes MS-DOS device names.
+--------------------------------------------------------------------------------
+-- Creates, modifies, or deletes a symbolic link for a DOS device name.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] dwFlags
+-- Control flags that specify the function's behavior. This parameter can be a
+-- combination of DefineDosDeviceFlags values.
+--------------------------------------------------------------------------------
+-- [in] lpDeviceName
+-- The device name string (for example, "COM1").
+--------------------------------------------------------------------------------
+-- [in, optional] lpTargetPath
+-- The path to which the device name refers. This can be NULL when removing a
+-- definition.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_INVALID_PARAMETER   87  (0x57)
+-- One or more parameters are invalid.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-definedosdevicew
 foreign import WINDOWS_CCONV unsafe "windows.h DefineDosDeviceW"
   c_DefineDosDevice :: DefineDosDeviceFlags -> LPCTSTR -> LPCTSTR -> IO Bool
 
@@ -504,28 +1585,134 @@ foreign import WINDOWS_CCONV unsafe "windows.h DefineDosDeviceW"
 -- These functions are very unusual in the Win32 API:
 -- They don't return error codes
 
+-- | Determines whether the file I/O functions are using the ANSI or OEM character set.
+--------------------------------------------------------------------------------
+-- Indicates whether the file APIs are set to use the ANSI character set or the
+-- OEM character set for file names and other string parameters.
+--
+-- Return value
+-- If the function succeeds, the return value is nonzero if the file APIs are
+-- using the ANSI character set, or zero if they are using the OEM character set.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-arefileapisansi
 foreign import WINDOWS_CCONV unsafe "windows.h AreFileApisANSI"
   areFileApisANSI :: IO Bool
 
+-- | Sets the file I/O functions to use the OEM character set.
+--------------------------------------------------------------------------------
+-- Configures the file APIs to use the OEM character set for file names and
+-- other string parameters instead of the ANSI character set.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfileapistooem
 foreign import WINDOWS_CCONV unsafe "windows.h SetFileApisToOEM"
   setFileApisToOEM :: IO ()
 
+-- | Sets the file I/O functions to use the ANSI character set.
+--------------------------------------------------------------------------------
+-- Configures the file APIs to use the ANSI character set for file names and
+-- other string parameters instead of the OEM character set.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfileapistoansi
 foreign import WINDOWS_CCONV unsafe "windows.h SetFileApisToANSI"
   setFileApisToANSI :: IO ()
 
+-- | Sets the maximum number of files that a process can have open simultaneously.
+--------------------------------------------------------------------------------
+-- Sets the size of the per-process file handle table, which determines the
+-- maximum number of files that the process can have open at the same time.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] uNumber
+-- The maximum number of open file handles for the process.
+--------------------------------------------------------------------------------
+-- Return value
+-- The return value is the previous maximum number of open file handles.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-sethandlecount
 foreign import WINDOWS_CCONV unsafe "windows.h SetHandleCount"
   setHandleCount :: UINT -> IO UINT
 
 ----------------------------------------------------------------
 
+-- | Retrieves a bitmask representing the currently available disk drives.
+--------------------------------------------------------------------------------
+-- Returns a bitmask in which each bit represents one logical drive present on
+-- the system.
+--
+-- Return value
+-- If the function succeeds, the return value is a bitmask representing the
+-- currently available disk drives. If the function fails, the return value is
+-- zero.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getlogicaldrives
 foreign import WINDOWS_CCONV unsafe "windows.h GetLogicalDrives"
   c_GetLogicalDrives :: IO DWORD
 
--- %fun GetDriveType :: Maybe String -> IO DriveType
-
+-- | Retrieves information about the amount of free and total space on a disk.
+--------------------------------------------------------------------------------
+-- Retrieves information about the specified disk, including the number of
+-- sectors per cluster, bytes per sector, number of free clusters, and total
+-- number of clusters.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] lpRootPathName
+-- The root directory of the disk to return information about (for example,
+-- "C:\").
+--------------------------------------------------------------------------------
+-- [out] lpSectorsPerCluster
+-- A pointer to a variable that receives the number of sectors per cluster.
+--------------------------------------------------------------------------------
+-- [out] lpBytesPerSector
+-- A pointer to a variable that receives the number of bytes per sector.
+--------------------------------------------------------------------------------
+-- [out] lpNumberOfFreeClusters
+-- A pointer to a variable that receives the total number of free clusters on
+-- the disk.
+--------------------------------------------------------------------------------
+-- [out] lpTotalNumberOfClusters
+-- A pointer to a variable that receives the total number of clusters on the
+-- disk.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_INVALID_PARAMETER   87  (0x57)
+-- One or more parameters are invalid.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getdiskfreespacew
 foreign import WINDOWS_CCONV unsafe "windows.h GetDiskFreeSpaceW"
   c_GetDiskFreeSpace :: LPCTSTR -> Ptr DWORD -> Ptr DWORD -> Ptr DWORD -> Ptr DWORD -> IO Bool
 
+-- | Sets the volume label for a specified disk volume.
+--------------------------------------------------------------------------------
+-- Assigns a new label to a disk volume.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] lpRootPathName
+-- The root directory of the volume to be labeled (for example, "C:\").
+--------------------------------------------------------------------------------
+-- [in, optional] lpVolumeName
+-- The new label for the volume. If this parameter is NULL, the label is deleted.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_INVALID_PARAMETER   87  (0x57)
+-- One or more parameters are invalid.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setvolumelabelw
 foreign import WINDOWS_CCONV unsafe "windows.h SetVolumeLabelW"
   c_SetVolumeLabel :: LPCTSTR -> LPCTSTR -> IO Bool
 
@@ -533,10 +1720,78 @@ foreign import WINDOWS_CCONV unsafe "windows.h SetVolumeLabelW"
 -- File locks
 ----------------------------------------------------------------
 
+-- | Locks a region of a file for exclusive or shared access.
+--------------------------------------------------------------------------------
+-- Locks a specified region of a file, preventing access by other processes
+-- depending on the requested lock mode.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] hFile
+-- A handle to the file to be locked.
+--------------------------------------------------------------------------------
+-- [in] dwFlags
+-- Specifies the lock mode. This parameter can be a combination of LockMode
+-- values.
+--------------------------------------------------------------------------------
+-- [in] dwReserved
+-- Reserved; must be zero.
+--------------------------------------------------------------------------------
+-- [in] nNumberOfBytesToLockLow
+-- The low-order part of the length of the byte range to lock.
+--------------------------------------------------------------------------------
+-- [in] nNumberOfBytesToLockHigh
+-- The high-order part of the length of the byte range to lock.
+--------------------------------------------------------------------------------
+-- [in, out] lpOverlapped
+-- A pointer to an OVERLAPPED structure that specifies the starting offset of
+-- the lock.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_LOCK_VIOLATION     33  (0x21)
+-- The process cannot access the file because another process has locked a
+-- portion of the file.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex
 foreign import WINDOWS_CCONV unsafe "LockFileEx"
   c_LockFileEx :: HANDLE -> DWORD -> DWORD -> DWORD -> DWORD -> LPOVERLAPPED
                -> IO BOOL
 
+-- | Unlocks a region of a file previously locked by LockFileEx.
+--------------------------------------------------------------------------------
+-- Unlocks a specified region of a file, allowing access by other processes.
+--
+-- Parameters:
+--------------------------------------------------------------------------------
+-- [in] hFile
+-- A handle to the file to be unlocked.
+--------------------------------------------------------------------------------
+-- [in] dwReserved
+-- Reserved; must be zero.
+--------------------------------------------------------------------------------
+-- [in] nNumberOfBytesToUnlockLow
+-- The low-order part of the length of the byte range to unlock.
+--------------------------------------------------------------------------------
+-- [in] nNumberOfBytesToUnlockHigh
+-- The high-order part of the length of the byte range to unlock.
+--------------------------------------------------------------------------------
+-- [in, out] lpOverlapped
+-- A pointer to an OVERLAPPED structure that specifies the starting offset of
+-- the unlock.
+--------------------------------------------------------------------------------
+-- Return value
+-- If the function succeeds, the return value is nonzero.
+-- If the function fails, the return value is zero.
+--
+-- ERROR_NOT_LOCKED         158 (0x9E)
+-- The region specified is not locked by the calling process.
+--------------------------------------------------------------------------------
+-- link to original documentation:
+-- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-unlockfileex
 foreign import WINDOWS_CCONV unsafe "UnlockFileEx"
   c_UnlockFileEx :: HANDLE -> DWORD -> DWORD -> DWORD -> LPOVERLAPPED -> IO BOOL
 

--- a/System/Win32/File/Internal.hsc
+++ b/System/Win32/File/Internal.hsc
@@ -286,10 +286,6 @@ fILE_FLAG_BACKUP_SEMANTICS = #const FILE_FLAG_BACKUP_SEMANTICS
 fILE_FLAG_POSIX_SEMANTICS :: FileAttributeOrFlag
 fILE_FLAG_POSIX_SEMANTICS = #const FILE_FLAG_POSIX_SEMANTICS
 
--- | (INVALID_FILE_ATTRIBUTES = 0xFFFFFFFF) Returned by GetFileAttributesW on failure.
-iNVALID_FILE_ATTRIBUTES :: FileAttributeOrFlag
-iNVALID_FILE_ATTRIBUTES = 0xFFFFFFFF
-
 #ifndef __WINE_WINDOWS_H
 -- | (SECURITY_ANONYMOUS = 0x0) The security anonymous level is set.
 sECURITY_ANONYMOUS :: FileAttributeOrFlag
@@ -674,146 +670,42 @@ instance Storable WIN32_FILE_ATTRIBUTE_DATA where
 -- File operations
 ----------------------------------------------------------------
 
--- | Deletes an existing file.
---
--- Possible errors:
--- ERROR_FILE_NOT_FOUND      2   (0x2)
--- ERROR_PATH_NOT_FOUND      3   (0x3)
--- ERROR_ACCESS_DENIED       5   (0x5)
--- ERROR_CURRENT_DIRECTORY  16   (0x10)
--- ERROR_WRITE_PROTECT      19   (0x13)
--- ERROR_SHARING_VIOLATION  32   (0x20)
--- ERROR_LOCK_VIOLATION     33   (0x21)
--- ERROR_INVALID_PARAMETER  87   (0x57)
--- ERROR_USER_MAPPED_FILE 1224   (0x4C8)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-deletefilew
 foreign import WINDOWS_CCONV unsafe "windows.h DeleteFileW"
   c_DeleteFile :: LPCTSTR -> IO Bool
 
--- | Copies an existing file to a new file.
---
--- Possible errors:
--- ERROR_FILE_NOT_FOUND      2   (0x2)
--- ERROR_PATH_NOT_FOUND      3   (0x3)
--- ERROR_ACCESS_DENIED       5   (0x5)
--- ERROR_SHARING_VIOLATION  32  (0x20)
--- ERROR_FILE_EXISTS        80  (0x50)
--- ERROR_ALREADY_EXISTS    183  (0xB7)
--- ERROR_INVALID_PARAMETER  87  (0x57)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-copyfilew
 foreign import WINDOWS_CCONV unsafe "windows.h CopyFileW"
   c_CopyFile :: LPCTSTR -> LPCTSTR -> Bool -> IO Bool
 
--- | Moves an existing file or directory to a new location.
---
--- Possible errors:
--- ERROR_FILE_NOT_FOUND      2   (0x2)
--- ERROR_PATH_NOT_FOUND      3   (0x3)
--- ERROR_ACCESS_DENIED       5   (0x5)
--- ERROR_ALREADY_EXISTS    183  (0xB7)
--- ERROR_SHARING_VIOLATION  32  (0x20)
--- ERROR_NOT_SAME_DEVICE    17  (0x11)
--- ERROR_INVALID_PARAMETER  87  (0x57)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefilew
 foreign import WINDOWS_CCONV unsafe "windows.h MoveFileW"
   c_MoveFile :: LPCTSTR -> LPCTSTR -> IO Bool
 
--- | Moves an existing file or directory, including its children.
---
--- Possible errors:
--- ERROR_FILE_NOT_FOUND      2   (0x2)
--- ERROR_PATH_NOT_FOUND      3   (0x3)
--- ERROR_ACCESS_DENIED       5   (0x5)
--- ERROR_ALREADY_EXISTS    183  (0xB7)
--- ERROR_SHARING_VIOLATION  32  (0x20)
--- ERROR_NOT_SAME_DEVICE    17  (0x11)
--- ERROR_INVALID_PARAMETER  87  (0x57)
--- ERROR_WRITE_PROTECT      19  (0x13)
--- ERROR_LOCK_VIOLATION     33  (0x21)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexw
 foreign import WINDOWS_CCONV unsafe "windows.h MoveFileExW"
   c_MoveFileEx :: LPCTSTR -> LPCTSTR -> MoveFileFlag -> IO Bool
 
--- | Changes the current directory for the current process.
---
--- Possible errors:
--- ERROR_FILE_NOT_FOUND      2   (0x2)
--- ERROR_PATH_NOT_FOUND      3   (0x3)
--- ERROR_ACCESS_DENIED       5   (0x5)
--- ERROR_INVALID_PARAMETER  87   (0x57)
--- ERROR_DIRECTORY         267   (0x10B)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setcurrentdirectory
 foreign import WINDOWS_CCONV unsafe "windows.h SetCurrentDirectoryW"
   c_SetCurrentDirectory :: LPCTSTR -> IO Bool
 
--- | Creates a new directory.
---
--- Possible errors:
--- ERROR_ALREADY_EXISTS         183  (0xB7)
--- ERROR_PATH_NOT_FOUND           3  (0x3)
--- ERROR_ACCESS_DENIED            5  (0x5)
--- ERROR_INVALID_PARAMETER       87  (0x57)
--- ERROR_FILENAME_EXCED_RANGE   206  (0xCE)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createdirectoryw
 foreign import WINDOWS_CCONV unsafe "windows.h CreateDirectoryW"
   c_CreateDirectory :: LPCTSTR -> LPSECURITY_ATTRIBUTES -> IO Bool
 
--- | Creates a directory as a copy of an existing directory.
---
--- Possible errors:
--- ERROR_ALREADY_EXISTS         183  (0xB7)
--- ERROR_PATH_NOT_FOUND           3  (0x3)
--- ERROR_ACCESS_DENIED            5  (0x5)
--- ERROR_INVALID_PARAMETER       87  (0x57)
--- ERROR_FILENAME_EXCED_RANGE   206  (0xCE)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createdirectoryexw
 foreign import WINDOWS_CCONV unsafe "windows.h CreateDirectoryExW"
   c_CreateDirectoryEx :: LPCTSTR -> LPCTSTR -> LPSECURITY_ATTRIBUTES -> IO Bool
 
--- | Removes (deletes) an existing empty directory.
---
--- Possible errors:
--- ERROR_PATH_NOT_FOUND           3   (0x3)
--- ERROR_ACCESS_DENIED            5   (0x5)
--- ERROR_SHARING_VIOLATION       32   (0x20)
--- ERROR_INVALID_PARAMETER       87   (0x57)
--- ERROR_DIRECTORY              267   (0x10B)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-removedirectoryw
 foreign import WINDOWS_CCONV unsafe "windows.h RemoveDirectoryW"
   c_RemoveDirectory :: LPCTSTR -> IO Bool
 
--- | Determines the type of a binary executable file.
---
--- Possible errors:
--- ERROR_FILE_NOT_FOUND           2   (0x2)
--- ERROR_PATH_NOT_FOUND           3   (0x3)
--- ERROR_INVALID_PARAMETER       87   (0x57)
--- ERROR_BAD_EXE_FORMAT         193   (0xC1)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getbinarytypew
 foreign import WINDOWS_CCONV unsafe "windows.h GetBinaryTypeW"
   c_GetBinaryType :: LPCTSTR -> Ptr DWORD -> IO Bool
 
--- | Replaces one file with another file.
---
--- Possible errors:
--- ERROR_FILE_NOT_FOUND                  2   (0x2)
--- ERROR_PATH_NOT_FOUND                  3   (0x3)
--- ERROR_ACCESS_DENIED                   5   (0x5)
--- ERROR_SHARING_VIOLATION              32   (0x20)
--- ERROR_INVALID_PARAMETER              87   (0x57)
--- ERROR_UNABLE_TO_REMOVE_REPLACED    1175   (0x497)
--- ERROR_UNABLE_TO_MOVE_REPLACEMENT   1176   (0x498)
--- ERROR_UNABLE_TO_MOVE_REPLACEMENT_2 1177   (0x499)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-replacefilew
 foreign import WINDOWS_CCONV unsafe "windows.h ReplaceFileW"
   c_ReplaceFile :: LPCWSTR -> LPCWSTR -> LPCWSTR -> DWORD -> LPVOID -> LPVOID -> IO Bool
@@ -822,32 +714,11 @@ foreign import WINDOWS_CCONV unsafe "windows.h ReplaceFileW"
 -- HANDLE operations
 ----------------------------------------------------------------
 
--- | Creates or opens a file or I/O device.
---
--- Possible errors:
--- ERROR_ALREADY_EXISTS    183   (0xB7)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew
 foreign import WINDOWS_CCONV unsafe "windows.h CreateFileW"
   c_CreateFile :: LPCTSTR -> AccessMode -> ShareMode -> LPSECURITY_ATTRIBUTES
                -> CreateMode -> FileAttributeOrFlag -> HANDLE -> IO HANDLE
 
--- | Closes an open object handle.
---
--- Possible errors:
--- ERROR_FILE_NOT_FOUND           2   (0x2)
--- ERROR_PATH_NOT_FOUND           3   (0x3)
--- ERROR_ACCESS_DENIED            5   (0x5)
--- ERROR_WRITE_PROTECT           19   (0x13)
--- ERROR_INVALID_HANDLE           6   (0x6)
--- ERROR_SHARING_VIOLATION       32   (0x20)
--- ERROR_FILE_EXISTS             80   (0x50)
--- ERROR_ALREADY_EXISTS         183   (0xB7)
--- ERROR_INVALID_PARAMETER       87   (0x57)
--- ERROR_INVALID_NAME           123   (0x7B)
--- ERROR_DISK_FULL              112   (0x70)
--- ERROR_DIRECTORY              267   (0x10B)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-closehandle
 foreign import WINDOWS_CCONV unsafe "windows.h CloseHandle"
   c_CloseHandle :: HANDLE -> IO Bool
@@ -861,79 +732,30 @@ foreign import WINDOWS_CCONV unsafe "windows.h CloseHandle"
 foreign import WINDOWS_CCONV unsafe "windows.h GetFileType"
   getFileType :: HANDLE -> IO FileType
 
--- | Flushes the buffers of a specified file and causes all buffered data to be written to disk.
---
--- Possible errors:
--- ERROR_INVALID_HANDLE    6   (0x6)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-flushfilebuffers
 foreign import WINDOWS_CCONV unsafe "windows.h FlushFileBuffers"
   c_FlushFileBuffers :: HANDLE -> IO Bool
 
--- | Sets the physical end of a file.
---
--- Possible errors:
--- ERROR_INVALID_HANDLE    6   (0x6)
--- ERROR_ACCESS_DENIED     5   (0x5)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setendoffile
 foreign import WINDOWS_CCONV unsafe "windows.h SetEndOfFile"
   c_SetEndOfFile :: HANDLE -> IO Bool
 
--- | Sets the attributes for a file or directory.
---
--- Possible errors:
--- ERROR_FILE_NOT_FOUND            2   (0x2)
--- ERROR_PATH_NOT_FOUND            3   (0x3)
--- ERROR_ACCESS_DENIED             5   (0x5)
--- ERROR_INVALID_PARAMETER        87   (0x57)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfileattributesw
 foreign import WINDOWS_CCONV unsafe "windows.h SetFileAttributesW"
   c_SetFileAttributes :: LPCTSTR -> FileAttributeOrFlag -> IO Bool
 
--- | Retrieves file system attributes for a specified file or directory.
---
--- Possible errors:
--- ERROR_FILE_NOT_FOUND            2   (0x2)
--- ERROR_PATH_NOT_FOUND            3   (0x3)
--- ERROR_INVALID_PARAMETER        87   (0x57)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfileattributesw
 foreign import WINDOWS_CCONV unsafe "windows.h GetFileAttributesW"
   c_GetFileAttributes :: LPCTSTR -> IO FileAttributeOrFlag
 
--- | Retrieves extended information about the specified file or directory.
---
--- Possible errors:
--- ERROR_FILE_NOT_FOUND            2   (0x2)
--- ERROR_PATH_NOT_FOUND            3   (0x3)
--- ERROR_INVALID_PARAMETER        87   (0x57)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfileattributesexw
 foreign import WINDOWS_CCONV unsafe "windows.h GetFileAttributesExW"
   c_GetFileAttributesEx :: LPCTSTR -> GET_FILEEX_INFO_LEVELS -> Ptr a -> IO BOOL
 
--- | Retrieves file information for the specified file.
---
--- Possible errors:
--- ERROR_INVALID_HANDLE            6   (0x6)
--- ERROR_ACCESS_DENIED             5   (0x5)
--- ERROR_INVALID_PARAMETER        87   (0x57)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfileinformationbyhandle
 foreign import WINDOWS_CCONV unsafe "windows.h GetFileInformationByHandle"
     c_GetFileInformationByHandle :: HANDLE -> Ptr BY_HANDLE_FILE_INFORMATION -> IO BOOL
 
--- | Creates a name for a temporary file and optionally creates the file.
---
--- Possible errors:
--- ERROR_DIRECTORY              267   (0x10B)
--- ERROR_ACCESS_DENIED            5   (0x5)
--- ERROR_INVALID_PARAMETER       87   (0x57)
--- ERROR_BUFFER_OVERFLOW        111   (0x6F)
--- ERROR_FILE_EXISTS             80   (0x50)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettempfilenamew
 foreign import WINDOWS_CCONV unsafe "windows.h GetTempFileNameW"
     c_GetTempFileNameW :: LPCWSTR -> LPCWSTR -> UINT -> LPWSTR -> IO UINT
@@ -973,42 +795,14 @@ type LPOVERLAPPED = Ptr OVERLAPPED
 
 type MbLPOVERLAPPED = Maybe LPOVERLAPPED
 
--- | Reads data from a file or input/output (I/O) device.
---
--- Possible errors:
--- ERROR_ACCESS_DENIED             5   (0x5)
--- ERROR_INVALID_HANDLE            6   (0x6)
--- ERROR_HANDLE_EOF               38   (0x26)
--- ERROR_BROKEN_PIPE             109   (0x6D)
--- ERROR_INVALID_PARAMETER        87   (0x57)
--- ERROR_IO_PENDING              997   (0x3E5)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-readfile
 foreign import WINDOWS_CCONV unsafe "windows.h ReadFile"
   c_ReadFile :: HANDLE -> Ptr a -> DWORD -> Ptr DWORD -> LPOVERLAPPED -> IO Bool
 
--- | Writes data to a file or input/output (I/O) device.
---
--- Possible errors:
--- ERROR_ACCESS_DENIED             5   (0x5)
--- ERROR_INVALID_HANDLE            6   (0x6)
--- ERROR_HANDLE_EOF               38   (0x26)
--- ERROR_BROKEN_PIPE             109   (0x6D)
--- ERROR_INVALID_PARAMETER        87   (0x57)
--- ERROR_DISK_FULL               112   (0x70)
--- ERROR_IO_PENDING              997   (0x3E5)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-writefile
 foreign import WINDOWS_CCONV unsafe "windows.h WriteFile"
   c_WriteFile :: HANDLE -> Ptr a -> DWORD -> Ptr DWORD -> LPOVERLAPPED -> IO Bool
 
--- | Moves the file pointer of an open file.
---
--- Possible errors:
--- ERROR_INVALID_HANDLE            6   (0x6)
--- ERROR_INVALID_PARAMETER        87   (0x57)
--- ERROR_NEGATIVE_SEEK           131   (0x83)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfilepointerex
 foreign import WINDOWS_CCONV unsafe "windows.h SetFilePointerEx"
   c_SetFilePointerEx :: HANDLE -> LARGE_INTEGER -> Ptr LARGE_INTEGER -> FilePtrDirection -> IO Bool
@@ -1020,31 +814,14 @@ foreign import WINDOWS_CCONV unsafe "windows.h SetFilePointerEx"
 -- on.
 ----------------------------------------------------------------
 
--- | Creates a change notification handle and sets up initial change notification filter conditions.
---
--- Possible errors:
--- ERROR_INVALID_PARAMETER        87   (0x57)
--- ERROR_PATH_NOT_FOUND            3   (0x3)
--- ERROR_ACCESS_DENIED             5   (0x5)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstchangenotificationw
 foreign import WINDOWS_CCONV unsafe "windows.h FindFirstChangeNotificationW"
   c_FindFirstChangeNotification :: LPCTSTR -> Bool -> FileNotificationFlag -> IO HANDLE
 
--- | Requests that the operating system signal a change notification handle when a change occurs.
---
--- Possible errors:
--- ERROR_INVALID_HANDLE    6   (0x6)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findnextchangenotification
 foreign import WINDOWS_CCONV unsafe "windows.h FindNextChangeNotification"
   c_FindNextChangeNotification :: HANDLE -> IO Bool
 
--- | Closes a change notification handle.
---
--- Possible errors:
--- ERROR_INVALID_HANDLE    6   (0x6)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findclosechangenotification
 foreign import WINDOWS_CCONV unsafe "windows.h FindCloseChangeNotification"
   c_FindCloseChangeNotification :: HANDLE -> IO Bool
@@ -1057,36 +834,14 @@ type WIN32_FIND_DATA = ()
 
 newtype FindData = FindData (ForeignPtr WIN32_FIND_DATA)
 
--- | Searches a directory for a file or subdirectory with a name that matches a specified pattern.
---
--- Possible errors:
--- ERROR_FILE_NOT_FOUND            2   (0x2)
--- ERROR_PATH_NOT_FOUND            3   (0x3)
--- ERROR_ACCESS_DENIED             5   (0x5)
--- ERROR_INVALID_PARAMETER        87   (0x57)
--- ERROR_INVALID_HANDLE            6   (0x6)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstfilew
 foreign import WINDOWS_CCONV unsafe "windows.h FindFirstFileW"
   c_FindFirstFile :: LPCTSTR -> Ptr WIN32_FIND_DATA -> IO HANDLE
 
--- | Continues a file search from a previous call to FindFirstFileW.
---
--- Possible errors:
--- ERROR_NO_MORE_FILES            18   (0x12)
--- ERROR_INVALID_HANDLE            6   (0x6)
--- ERROR_ACCESS_DENIED             5   (0x5)
--- ERROR_INVALID_PARAMETER        87   (0x57)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findnextfilew
 foreign import WINDOWS_CCONV unsafe "windows.h FindNextFileW"
   c_FindNextFile :: HANDLE -> Ptr WIN32_FIND_DATA -> IO BOOL
 
--- | Closes a file search handle.
---
--- Possible errors:
--- ERROR_INVALID_HANDLE    6   (0x6)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findclose
 foreign import WINDOWS_CCONV unsafe "windows.h FindClose"
   c_FindClose :: HANDLE -> IO BOOL
@@ -1095,13 +850,6 @@ foreign import WINDOWS_CCONV unsafe "windows.h FindClose"
 -- DOS Device flags
 ----------------------------------------------------------------
 
--- | Defines, modifies, or deletes MS-DOS device names.
---
--- Possible errors:
--- ERROR_INVALID_PARAMETER        87   (0x57)
--- ERROR_ACCESS_DENIED             5   (0x5)
--- ERROR_FILE_NOT_FOUND            2   (0x2)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-definedosdevicew
 foreign import WINDOWS_CCONV unsafe "windows.h DefineDosDeviceW"
   c_DefineDosDevice :: DefineDosDeviceFlags -> LPCTSTR -> LPCTSTR -> IO Bool
@@ -1116,6 +864,7 @@ foreign import WINDOWS_CCONV unsafe "windows.h DefineDosDeviceW"
 -- Possible errors:
 -- ERROR_INVALID_PARAMETER        87   (0x57)
 --
+-- Link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-arefileapisansi
 foreign import WINDOWS_CCONV unsafe "windows.h AreFileApisANSI"
   areFileApisANSI :: IO Bool
@@ -1125,6 +874,7 @@ foreign import WINDOWS_CCONV unsafe "windows.h AreFileApisANSI"
 -- Possible errors:
 -- ERROR_INVALID_PARAMETER        87   (0x57)
 --
+-- Link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfileapistooem
 foreign import WINDOWS_CCONV unsafe "windows.h SetFileApisToOEM"
   setFileApisToOEM :: IO ()
@@ -1134,6 +884,7 @@ foreign import WINDOWS_CCONV unsafe "windows.h SetFileApisToOEM"
 -- Possible errors:
 -- ERROR_INVALID_PARAMETER        87   (0x57)
 --
+-- Link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfileapistoansi
 foreign import WINDOWS_CCONV unsafe "windows.h SetFileApisToANSI"
   setFileApisToANSI :: IO ()
@@ -1143,42 +894,21 @@ foreign import WINDOWS_CCONV unsafe "windows.h SetFileApisToANSI"
 -- Possible errors:
 -- ERROR_INVALID_PARAMETER        87   (0x57)
 --
+-- Link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-sethandlecount
 foreign import WINDOWS_CCONV unsafe "windows.h SetHandleCount"
   setHandleCount :: UINT -> IO UINT
 
 ----------------------------------------------------------------
 
--- | Retrieves a bitmask representing the currently available disk drives.
---
--- Possible errors:
--- ERROR_INVALID_FUNCTION          1   (0x1)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getlogicaldrives
 foreign import WINDOWS_CCONV unsafe "windows.h GetLogicalDrives"
   c_GetLogicalDrives :: IO DWORD
 
--- | Retrieves information about the amount of free and total space on a disk.
---
--- Possible errors:
--- ERROR_INVALID_FUNCTION          1   (0x1)
--- ERROR_PATH_NOT_FOUND            3   (0x3)
--- ERROR_ACCESS_DENIED             5   (0x5)
--- ERROR_INVALID_PARAMETER        87   (0x57)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getdiskfreespacew
 foreign import WINDOWS_CCONV unsafe "windows.h GetDiskFreeSpaceW"
   c_GetDiskFreeSpace :: LPCTSTR -> Ptr DWORD -> Ptr DWORD -> Ptr DWORD -> Ptr DWORD -> IO Bool
 
--- | Sets the volume label for a specified disk volume.
---
--- Possible errors:
--- ERROR_ACCESS_DENIED             5   (0x5)
--- ERROR_INVALID_PARAMETER        87   (0x57)
--- ERROR_LABEL_TOO_LONG          154   (0x9A)
--- ERROR_INVALID_NAME            123   (0x7B)
--- ERROR_DIRECTORY               267   (0x10B)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setvolumelabelw
 foreign import WINDOWS_CCONV unsafe "windows.h SetVolumeLabelW"
   c_SetVolumeLabel :: LPCTSTR -> LPCTSTR -> IO Bool
@@ -1187,26 +917,11 @@ foreign import WINDOWS_CCONV unsafe "windows.h SetVolumeLabelW"
 -- File locks
 ----------------------------------------------------------------
 
--- | Locks a region of a file for exclusive or shared access.
---
--- Possible errors:
--- ERROR_INVALID_HANDLE            6   (0x6)
--- ERROR_LOCK_VIOLATION           33   (0x21)
--- ERROR_NOT_ENOUGH_MEMORY        8    (0x8)
--- ERROR_INVALID_PARAMETER        87   (0x57)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex
 foreign import WINDOWS_CCONV unsafe "LockFileEx"
   c_LockFileEx :: HANDLE -> DWORD -> DWORD -> DWORD -> DWORD -> LPOVERLAPPED
                -> IO BOOL
 
--- | Unlocks a region of a file previously locked by LockFileEx.
---
--- Possible errors:
--- ERROR_INVALID_HANDLE            6   (0x6)
--- ERROR_NOT_LOCKED              158   (0x9E)
--- ERROR_INVALID_PARAMETER        87   (0x57)
---
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-unlockfileex
 foreign import WINDOWS_CCONV unsafe "UnlockFileEx"
   c_UnlockFileEx :: HANDLE -> DWORD -> DWORD -> DWORD -> LPOVERLAPPED -> IO BOOL

--- a/System/Win32/File/Internal.hsc
+++ b/System/Win32/File/Internal.hsc
@@ -286,6 +286,10 @@ fILE_FLAG_BACKUP_SEMANTICS = #const FILE_FLAG_BACKUP_SEMANTICS
 fILE_FLAG_POSIX_SEMANTICS :: FileAttributeOrFlag
 fILE_FLAG_POSIX_SEMANTICS = #const FILE_FLAG_POSIX_SEMANTICS
 
+-- | (INVALID_FILE_ATTRIBUTES = 0xFFFFFFFF) Returned by GetFileAttributesW on failure.
+iNVALID_FILE_ATTRIBUTES :: FileAttributeOrFlag
+iNVALID_FILE_ATTRIBUTES = 0xFFFFFFFF
+
 #ifndef __WINE_WINDOWS_H
 -- | (SECURITY_ANONYMOUS = 0x0) The security anonymous level is set.
 sECURITY_ANONYMOUS :: FileAttributeOrFlag
@@ -671,313 +675,145 @@ instance Storable WIN32_FILE_ATTRIBUTE_DATA where
 ----------------------------------------------------------------
 
 -- | Deletes an existing file.
---------------------------------------------------------------------------------
--- Deletes the specified file. If the file is open or in use, the function fails.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] lpFileName
--- The name of the file to be deleted.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND      2   (0x2)
+-- ERROR_PATH_NOT_FOUND      3   (0x3)
+-- ERROR_ACCESS_DENIED       5   (0x5)
+-- ERROR_CURRENT_DIRECTORY  16   (0x10)
+-- ERROR_WRITE_PROTECT      19   (0x13)
+-- ERROR_SHARING_VIOLATION  32   (0x20)
+-- ERROR_LOCK_VIOLATION     33   (0x21)
+-- ERROR_INVALID_PARAMETER  87   (0x57)
+-- ERROR_USER_MAPPED_FILE 1224   (0x4C8)
 --
--- ERROR_SHARING_VIOLATION  32  (0x20)
--- The file is being used by another process.
---------------------------------------------------------------------------------
--- link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-deletefilew
 foreign import WINDOWS_CCONV unsafe "windows.h DeleteFileW"
   c_DeleteFile :: LPCTSTR -> IO Bool
 
 -- | Copies an existing file to a new file.
---------------------------------------------------------------------------------
--- Copies an existing file to a new file. The copy fails if the destination file
--- already exists, unless the failIfExists parameter is set to FALSE.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] lpExistingFileName
--- The name of an existing file.
---------------------------------------------------------------------------------
--- [in] lpNewFileName
--- The name of the new file.
---------------------------------------------------------------------------------
--- [in] bFailIfExists
--- If this parameter is TRUE and the new file specified by lpNewFileName already
--- exists, the function fails. If this parameter is FALSE and the new file
--- already exists, the function overwrites the existing file and succeeds.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
---
--- ERROR_FILE_EXISTS        80  (0x50)
--- The destination file already exists and bFailIfExists is TRUE.
---
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND      2   (0x2)
+-- ERROR_PATH_NOT_FOUND      3   (0x3)
+-- ERROR_ACCESS_DENIED       5   (0x5)
 -- ERROR_SHARING_VIOLATION  32  (0x20)
--- The file is being used by another process.
---------------------------------------------------------------------------------
--- link to original documentation:
+-- ERROR_FILE_EXISTS        80  (0x50)
+-- ERROR_ALREADY_EXISTS    183  (0xB7)
+-- ERROR_INVALID_PARAMETER  87  (0x57)
+--
 -- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-copyfilew
 foreign import WINDOWS_CCONV unsafe "windows.h CopyFileW"
   c_CopyFile :: LPCTSTR -> LPCTSTR -> Bool -> IO Bool
 
 -- | Moves an existing file or directory to a new location.
---------------------------------------------------------------------------------
--- Moves an existing file or directory to a new location. The move fails if the
--- destination already exists.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] lpExistingFileName
--- The current name of the file or directory.
---------------------------------------------------------------------------------
--- [in] lpNewFileName
--- The new name for the file or directory.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND      2   (0x2)
+-- ERROR_PATH_NOT_FOUND      3   (0x3)
+-- ERROR_ACCESS_DENIED       5   (0x5)
+-- ERROR_ALREADY_EXISTS    183  (0xB7)
+-- ERROR_SHARING_VIOLATION  32  (0x20)
+-- ERROR_NOT_SAME_DEVICE    17  (0x11)
+-- ERROR_INVALID_PARAMETER  87  (0x57)
 --
--- ERROR_ALREADY_EXISTS      183 (0xB7)
--- The destination already exists and cannot be replaced.
---
--- ERROR_SHARING_VIOLATION   32 (0x20)
--- The file is being used by another process.
---
--- ERROR_NOT_SAME_DEVICE     17 (0x11)
--- The file cannot be moved to a different disk drive.
---------------------------------------------------------------------------------
--- link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefilew
 foreign import WINDOWS_CCONV unsafe "windows.h MoveFileW"
   c_MoveFile :: LPCTSTR -> LPCTSTR -> IO Bool
 
 -- | Moves an existing file or directory, including its children.
---------------------------------------------------------------------------------
--- Moves an existing file or directory to a new location, with the option to
--- replace the destination file or directory if it already exists.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] lpExistingFileName
--- The current name of the file or directory.
---------------------------------------------------------------------------------
--- [in] lpNewFileName
--- The new name for the file or directory.
---------------------------------------------------------------------------------
--- [in] dwFlags
--- Move options. This parameter can be one or more of the following values:
---   MOVEFILE_REPLACE_EXISTING    0x00000001
---   MOVEFILE_COPY_ALLOWED        0x00000002
---   MOVEFILE_DELAY_UNTIL_REBOOT  0x00000004
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND      2   (0x2)
+-- ERROR_PATH_NOT_FOUND      3   (0x3)
+-- ERROR_ACCESS_DENIED       5   (0x5)
+-- ERROR_ALREADY_EXISTS    183  (0xB7)
+-- ERROR_SHARING_VIOLATION  32  (0x20)
+-- ERROR_NOT_SAME_DEVICE    17  (0x11)
+-- ERROR_INVALID_PARAMETER  87  (0x57)
+-- ERROR_WRITE_PROTECT      19  (0x13)
+-- ERROR_LOCK_VIOLATION     33  (0x21)
 --
--- ERROR_ALREADY_EXISTS      183 (0xB7)
--- The destination already exists and cannot be replaced.
---
--- ERROR_SHARING_VIOLATION   32 (0x20)
--- The file is being used by another process.
---
--- ERROR_NOT_SAME_DEVICE     17 (0x11)
--- The file cannot be moved to a different disk drive.
---------------------------------------------------------------------------------
--- link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexw
 foreign import WINDOWS_CCONV unsafe "windows.h MoveFileExW"
   c_MoveFileEx :: LPCTSTR -> LPCTSTR -> MoveFileFlag -> IO Bool
 
 -- | Changes the current directory for the current process.
---------------------------------------------------------------------------------
--- Sets the current directory for the current process to the specified path.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] lpPathName
--- The path to the new current directory.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
--- Or returns common errors.
---------------------------------------------------------------------------------
--- link to original documentation:
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND      2   (0x2)
+-- ERROR_PATH_NOT_FOUND      3   (0x3)
+-- ERROR_ACCESS_DENIED       5   (0x5)
+-- ERROR_INVALID_PARAMETER  87   (0x57)
+-- ERROR_DIRECTORY         267   (0x10B)
+--
 -- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setcurrentdirectory
 foreign import WINDOWS_CCONV unsafe "windows.h SetCurrentDirectoryW"
   c_SetCurrentDirectory :: LPCTSTR -> IO Bool
 
 -- | Creates a new directory.
---------------------------------------------------------------------------------
--- Creates a new directory with the specified name. The security descriptor of
--- the new directory can be specified.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] lpPathName
--- The path of the directory to be created.
---------------------------------------------------------------------------------
--- [in, optional] lpSecurityAttributes
--- A pointer to a SECURITY_ATTRIBUTES structure that determines whether the
--- returned handle can be inherited by child processes. Can be NULL.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
+-- Possible errors:
+-- ERROR_ALREADY_EXISTS         183  (0xB7)
+-- ERROR_PATH_NOT_FOUND           3  (0x3)
+-- ERROR_ACCESS_DENIED            5  (0x5)
+-- ERROR_INVALID_PARAMETER       87  (0x57)
+-- ERROR_FILENAME_EXCED_RANGE   206  (0xCE)
 --
--- ERROR_ALREADY_EXISTS   183 (0xB7)
--- The directory already exists.
---------------------------------------------------------------------------------
--- link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createdirectoryw
 foreign import WINDOWS_CCONV unsafe "windows.h CreateDirectoryW"
   c_CreateDirectory :: LPCTSTR -> LPSECURITY_ATTRIBUTES -> IO Bool
 
 -- | Creates a directory as a copy of an existing directory.
---------------------------------------------------------------------------------
--- Creates a new directory with the attributes and security descriptor of an existing directory.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] lpTemplateDirectory
--- The path of an existing directory whose attributes and security descriptor
--- are to be copied to the new directory.
---------------------------------------------------------------------------------
--- [in] lpNewDirectory
--- The path of the directory to be created.
---------------------------------------------------------------------------------
--- [in, optional] lpSecurityAttributes
--- A pointer to a SECURITY_ATTRIBUTES structure that determines whether the
--- returned handle can be inherited by child processes. Can be NULL.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
+-- Possible errors:
+-- ERROR_ALREADY_EXISTS         183  (0xB7)
+-- ERROR_PATH_NOT_FOUND           3  (0x3)
+-- ERROR_ACCESS_DENIED            5  (0x5)
+-- ERROR_INVALID_PARAMETER       87  (0x57)
+-- ERROR_FILENAME_EXCED_RANGE   206  (0xCE)
 --
--- ERROR_ALREADY_EXISTS   183 (0xB7)
--- The directory already exists.
---------------------------------------------------------------------------------
--- link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createdirectoryexw
 foreign import WINDOWS_CCONV unsafe "windows.h CreateDirectoryExW"
   c_CreateDirectoryEx :: LPCTSTR -> LPCTSTR -> LPSECURITY_ATTRIBUTES -> IO Bool
 
 -- | Removes (deletes) an existing empty directory.
---------------------------------------------------------------------------------
--- Deletes the specified empty directory. If the directory is not empty or is in use,
--- the function fails.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] lpPathName
--- The path of the directory to be removed. The path must specify an empty directory,
--- and the calling process must have delete access to the directory.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
+-- Possible errors:
+-- ERROR_PATH_NOT_FOUND           3   (0x3)
+-- ERROR_ACCESS_DENIED            5   (0x5)
+-- ERROR_SHARING_VIOLATION       32   (0x20)
+-- ERROR_INVALID_PARAMETER       87   (0x57)
+-- ERROR_DIRECTORY              267   (0x10B)
 --
--- ERROR_DIR_NOT_EMPTY      145 (0x91)
--- The directory is not empty.
---
--- ERROR_SHARING_VIOLATION  32  (0x20)
--- The directory is being used by another process.
---------------------------------------------------------------------------------
--- link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-removedirectoryw
 foreign import WINDOWS_CCONV unsafe "windows.h RemoveDirectoryW"
   c_RemoveDirectory :: LPCTSTR -> IO Bool
 
 -- | Determines the type of a binary executable file.
---------------------------------------------------------------------------------
--- Determines whether a file is executable, and if so, what type of executable
--- it is (e.g., console application, Windows application, etc.).
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] lpApplicationName
--- The full path of the binary executable file for which to determine the type.
---------------------------------------------------------------------------------
--- [out] lpBinaryType
--- A pointer to a variable that receives the binary type. This parameter can
--- be one of the following values:
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND           2   (0x2)
+-- ERROR_PATH_NOT_FOUND           3   (0x3)
+-- ERROR_INVALID_PARAMETER       87   (0x57)
+-- ERROR_BAD_EXE_FORMAT         193   (0xC1)
 --
--- SCS_32BIT_BINARY 0 (32-bit Windows-based application)
--- SCS_64BIT_BINARY 6 (64-bit Windows-based application)
--- SCS_DOS_BINARY   1 (MS-DOS-based application)
--- SCS_OS216_BINARY 5 (16-bit OS/2-based application) (not supported on 64-bit Windows)
--- SCS_PIF_BINARY   3 (PIF file that executes an MS-DOS-based application)
--- SCS_POSIX_BINARY 4 (POSIX-based application)
--- SCS_WOW_BINARY   2 (16-bit Windows-based application)
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
---
--- ERROR_BAD_EXE_FORMAT    193 (0xC1)
--- The specified file is not a valid executable file.
---
--- ERROR_INVALID_PARAMETER 87  (0x57)
--- The lpBinaryType parameter is NULL or the specified file is not a valid executable file.
---------------------------------------------------------------------------------
--- link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getbinarytypew
 foreign import WINDOWS_CCONV unsafe "windows.h GetBinaryTypeW"
   c_GetBinaryType :: LPCTSTR -> Ptr DWORD -> IO Bool
 
 -- | Replaces one file with another file.
---------------------------------------------------------------------------------
--- Replaces one file with another file, with the option of creating a backup
--- copy of the original file. The replacement file assumes the name of the
--- replaced file and its identity.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] lpReplacedFileName
--- The name of the file to be replaced.
---------------------------------------------------------------------------------
--- [in] lpReplacementFileName
--- The name of the file that will replace the lpReplacedFileName file.
---------------------------------------------------------------------------------
--- [in, optional] lpBackupFileName
--- The name of the file that will serve as a backup copy of the lpReplacedFileName file.
---------------------------------------------------------------------------------
--- [in] dwReplaceFlags
--- The replacement options. This parameter can be one or more of the following values.
--- 
--- REPLACEFILE_WRITE_THROUGH 0x00000001
--- This value is not supported.
--- 
--- REPLACEFILE_IGNORE_MERGE_ERRORS 0x00000002
--- Ignores errors that occur while merging information.
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND                  2   (0x2)
+-- ERROR_PATH_NOT_FOUND                  3   (0x3)
+-- ERROR_ACCESS_DENIED                   5   (0x5)
+-- ERROR_SHARING_VIOLATION              32   (0x20)
+-- ERROR_INVALID_PARAMETER              87   (0x57)
+-- ERROR_UNABLE_TO_REMOVE_REPLACED    1175   (0x497)
+-- ERROR_UNABLE_TO_MOVE_REPLACEMENT   1176   (0x498)
+-- ERROR_UNABLE_TO_MOVE_REPLACEMENT_2 1177   (0x499)
 --
--- REPLACEFILE_IGNORE_ACL_ERRORS 0x00000004
--- Ignores errors that occur while merging ACL information.
---------------------------------------------------------------------------------
--- lpExclude
--- Reserved for future use.
---------------------------------------------------------------------------------
--- lpReserved
--- Reserved for future use.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
---
--- ERROR_UNABLE_TO_MOVE_REPLACEMENT   1176 (0x498)
--- The replacement file could not be renamed.
---
--- ERROR_UNABLE_TO_MOVE_REPLACEMENT_2 1177 (0x499)
--- The replacement file could not be moved.
---
--- ERROR_UNABLE_TO_REMOVE_REPLACED    1175 (0x497)
--- The replaced file could not be deleted.
---------------------------------------------------------------------------------
--- link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-replacefilew
 foreign import WINDOWS_CCONV unsafe "windows.h ReplaceFileW"
   c_ReplaceFile :: LPCWSTR -> LPCWSTR -> LPCWSTR -> DWORD -> LPVOID -> LPVOID -> IO Bool
@@ -987,264 +823,117 @@ foreign import WINDOWS_CCONV unsafe "windows.h ReplaceFileW"
 ----------------------------------------------------------------
 
 -- | Creates or opens a file or I/O device.
---------------------------------------------------------------------------------
--- Creates or opens a file, directory, physical disk, volume, console buffer,
--- tape drive, communications resource, or other I/O device.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] lpFileName
--- The name of the file or device to be created or opened.
---------------------------------------------------------------------------------
--- [in] dwDesiredAccess
--- The requested access to the file or device (see AccessMode).
---------------------------------------------------------------------------------
--- [in] dwShareMode
--- The requested sharing mode of the file or device (see ShareMode).
---------------------------------------------------------------------------------
--- [in, optional] lpSecurityAttributes
--- A pointer to a SECURITY_ATTRIBUTES structure that determines whether the
--- returned handle can be inherited by child processes. Can be NULL.
---------------------------------------------------------------------------------
--- [in] dwCreationDisposition
--- An action to take on files that exist or do not exist (see CreateMode).
---------------------------------------------------------------------------------
--- [in] dwFlagsAndAttributes
--- The file or device attributes and flags (see FileAttributeOrFlag).
---------------------------------------------------------------------------------
--- [in, optional] hTemplateFile
--- A valid handle to a template file with the GENERIC_READ access right.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is an open handle to the specified
--- file, device, or I/O resource.
--- If the function fails, the return value is INVALID_HANDLE_VALUE.
---
+-- Possible errors:
 -- ERROR_ALREADY_EXISTS    183   (0xB7)
--- The file already exists and cannot be created.
---------------------------------------------------------------------------------
--- link to original documentation:
+--
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew
 foreign import WINDOWS_CCONV unsafe "windows.h CreateFileW"
   c_CreateFile :: LPCTSTR -> AccessMode -> ShareMode -> LPSECURITY_ATTRIBUTES
                -> CreateMode -> FileAttributeOrFlag -> HANDLE -> IO HANDLE
 
 -- | Closes an open object handle.
---------------------------------------------------------------------------------
--- Closes an open handle to an object, such as a file, process, thread, or
--- registry key.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] hObject
--- A valid handle to an open object.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND           2   (0x2)
+-- ERROR_PATH_NOT_FOUND           3   (0x3)
+-- ERROR_ACCESS_DENIED            5   (0x5)
+-- ERROR_WRITE_PROTECT           19   (0x13)
+-- ERROR_INVALID_HANDLE           6   (0x6)
+-- ERROR_SHARING_VIOLATION       32   (0x20)
+-- ERROR_FILE_EXISTS             80   (0x50)
+-- ERROR_ALREADY_EXISTS         183   (0xB7)
+-- ERROR_INVALID_PARAMETER       87   (0x57)
+-- ERROR_INVALID_NAME           123   (0x7B)
+-- ERROR_DISK_FULL              112   (0x70)
+-- ERROR_DIRECTORY              267   (0x10B)
 --
--- ERROR_INVALID_HANDLE    6   (0x6)
--- The handle is invalid.
---------------------------------------------------------------------------------
--- link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-closehandle
 foreign import WINDOWS_CCONV unsafe "windows.h CloseHandle"
   c_CloseHandle :: HANDLE -> IO Bool
 
 -- | Retrieves the file type of the specified file.
---------------------------------------------------------------------------------
--- Determines the type of a file (disk file, character file, pipe, etc.) based
--- on the specified file handle.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] hFile
--- A handle to the file whose type is to be determined.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value indicates the FileType.
--- If the function fails, the return value is FILE_TYPE_UNKNOWN.
---------------------------------------------------------------------------------
--- link to original documentation:
+-- Possible errors:
+-- FILE_TYPE_UNKNOWN       0   (0x0)
+--
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfiletype
 foreign import WINDOWS_CCONV unsafe "windows.h GetFileType"
   getFileType :: HANDLE -> IO FileType
 
 -- | Flushes the buffers of a specified file and causes all buffered data to be written to disk.
---------------------------------------------------------------------------------
--- Writes all buffered data for the specified file to disk. This ensures that
--- all data written to the file so far is physically stored on the disk device.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] hFile
--- A handle to the open file whose buffers are to be flushed. The handle must
--- have write access.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
---
+-- Possible errors:
 -- ERROR_INVALID_HANDLE    6   (0x6)
--- The handle is invalid.
---------------------------------------------------------------------------------
--- link to original documentation:
+--
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-flushfilebuffers
 foreign import WINDOWS_CCONV unsafe "windows.h FlushFileBuffers"
   c_FlushFileBuffers :: HANDLE -> IO Bool
 
 -- | Sets the physical end of a file.
---------------------------------------------------------------------------------
--- Moves the end-of-file (EOF) position for the specified file to the current
--- position of the file pointer. This function can be used to truncate or extend
--- a file.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] hFile
--- A handle to the file. The file handle must have GENERIC_WRITE access.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
---
+-- Possible errors:
 -- ERROR_INVALID_HANDLE    6   (0x6)
--- The handle is invalid.
---------------------------------------------------------------------------------
--- link to original documentation:
+-- ERROR_ACCESS_DENIED     5   (0x5)
+--
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setendoffile
 foreign import WINDOWS_CCONV unsafe "windows.h SetEndOfFile"
   c_SetEndOfFile :: HANDLE -> IO Bool
 
 -- | Sets the attributes for a file or directory.
---------------------------------------------------------------------------------
--- Sets the file system attributes for a specified file or directory.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] lpFileName
--- The name of the file or directory whose attributes are to be set.
---------------------------------------------------------------------------------
--- [in] dwFileAttributes
--- The file attributes to set for the file or directory. This parameter can be
--- a combination of FileAttributeOrFlag values.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND            2   (0x2)
+-- ERROR_PATH_NOT_FOUND            3   (0x3)
+-- ERROR_ACCESS_DENIED             5   (0x5)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
 --
--- ERROR_INVALID_PARAMETER   87  (0x57)
--- One or more parameters are invalid.
---------------------------------------------------------------------------------
--- link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfileattributesw
 foreign import WINDOWS_CCONV unsafe "windows.h SetFileAttributesW"
   c_SetFileAttributes :: LPCTSTR -> FileAttributeOrFlag -> IO Bool
 
 -- | Retrieves file system attributes for a specified file or directory.
---------------------------------------------------------------------------------
--- Retrieves attribute information for a specified file or directory.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] lpFileName
--- The name of the file or directory.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is the attributes of the file or directory.
--- If the function fails, the return value is INVALID_FILE_ATTRIBUTES.
---------------------------------------------------------------------------------
--- link to original documentation:
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND            2   (0x2)
+-- ERROR_PATH_NOT_FOUND            3   (0x3)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+--
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfileattributesw
 foreign import WINDOWS_CCONV unsafe "windows.h GetFileAttributesW"
   c_GetFileAttributes :: LPCTSTR -> IO FileAttributeOrFlag
 
 -- | Retrieves extended information about the specified file or directory.
---------------------------------------------------------------------------------
--- Retrieves attributes for a specified file or directory, including times and
--- file size, and stores them in a WIN32_FILE_ATTRIBUTE_DATA structure.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] lpFileName
--- The name of the file or directory.
---------------------------------------------------------------------------------
--- [in] fInfoLevelId
--- The information level to retrieve. Must be GetFileExInfoStandard.
---------------------------------------------------------------------------------
--- [out] lpFileInformation
--- A pointer to a buffer that receives the attribute data (typically a
--- WIN32_FILE_ATTRIBUTE_DATA structure).
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND            2   (0x2)
+-- ERROR_PATH_NOT_FOUND            3   (0x3)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
 --
--- ERROR_INVALID_PARAMETER   87  (0x57)
--- One or more parameters are invalid.
---------------------------------------------------------------------------------
--- link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfileattributesexw
 foreign import WINDOWS_CCONV unsafe "windows.h GetFileAttributesExW"
   c_GetFileAttributesEx :: LPCTSTR -> GET_FILEEX_INFO_LEVELS -> Ptr a -> IO BOOL
 
 -- | Retrieves file information for the specified file.
---------------------------------------------------------------------------------
--- Retrieves information about a file based on the file handle. The information
--- includes attributes, times, size, and more.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] hFile
--- A handle to the file for which information is to be retrieved.
---------------------------------------------------------------------------------
--- [out] lpFileInformation
--- A pointer to a BY_HANDLE_FILE_INFORMATION structure that receives the file
--- information.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
--- Or returns common errors.
---------------------------------------------------------------------------------
--- link to original documentation:
+-- Possible errors:
+-- ERROR_INVALID_HANDLE            6   (0x6)
+-- ERROR_ACCESS_DENIED             5   (0x5)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+--
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfileinformationbyhandle
 foreign import WINDOWS_CCONV unsafe "windows.h GetFileInformationByHandle"
     c_GetFileInformationByHandle :: HANDLE -> Ptr BY_HANDLE_FILE_INFORMATION -> IO BOOL
 
 -- | Creates a name for a temporary file and optionally creates the file.
---------------------------------------------------------------------------------
--- Generates a unique temporary file name, and optionally creates the file in
--- the specified directory.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] lpPathName
--- The directory in which the temporary file will be created.
---------------------------------------------------------------------------------
--- [in] lpPrefixString
--- The prefix of the temporary file name. The function uses the first three
--- characters of this string as the prefix.
---------------------------------------------------------------------------------
--- [in] uUnique
--- If this parameter is zero, the function creates the file. If it is nonzero,
--- the function only generates a unique file name.
---------------------------------------------------------------------------------
--- [out] lpTempFileName
--- A buffer that receives the temporary file name.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is the length, in characters, of
--- the string copied to lpTempFileName, not including the terminating null
--- character.
+-- Possible errors:
+-- ERROR_DIRECTORY              267   (0x10B)
+-- ERROR_ACCESS_DENIED            5   (0x5)
+-- ERROR_INVALID_PARAMETER       87   (0x57)
+-- ERROR_BUFFER_OVERFLOW        111   (0x6F)
+-- ERROR_FILE_EXISTS             80   (0x50)
 --
--- ERROR_BUFFER_OVERFLOW   111 (0x6F)
--- The buffer is too small to hold the generated file name.
---
--- ERROR_DIRECTORY         267 (0x10B)
--- The specified path is invalid.
---------------------------------------------------------------------------------
--- link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettempfilenamew
 foreign import WINDOWS_CCONV unsafe "windows.h GetTempFileNameW"
     c_GetTempFileNameW :: LPCWSTR -> LPCWSTR -> UINT -> LPWSTR -> IO UINT
@@ -1285,100 +974,41 @@ type LPOVERLAPPED = Ptr OVERLAPPED
 type MbLPOVERLAPPED = Maybe LPOVERLAPPED
 
 -- | Reads data from a file or input/output (I/O) device.
---------------------------------------------------------------------------------
--- Reads data from the specified file or input/output device into a buffer.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] hFile
--- A handle to the file or I/O device to be read.
---------------------------------------------------------------------------------
--- [out] lpBuffer
--- A pointer to the buffer that receives the data read from the file or device.
---------------------------------------------------------------------------------
--- [in] nNumberOfBytesToRead
--- The maximum number of bytes to be read.
---------------------------------------------------------------------------------
--- [out, optional] lpNumberOfBytesRead
--- A pointer to the variable that receives the number of bytes read.
---------------------------------------------------------------------------------
--- [in, optional] lpOverlapped
--- A pointer to an OVERLAPPED structure for asynchronous operations. Can be NULL
--- for synchronous operations.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
+-- Possible errors:
+-- ERROR_ACCESS_DENIED             5   (0x5)
+-- ERROR_INVALID_HANDLE            6   (0x6)
+-- ERROR_HANDLE_EOF               38   (0x26)
+-- ERROR_BROKEN_PIPE             109   (0x6D)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+-- ERROR_IO_PENDING              997   (0x3E5)
 --
--- ERROR_IO_PENDING        997 (0x3E5)
--- An overlapped I/O operation is in progress.
---------------------------------------------------------------------------------
--- link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-readfile
 foreign import WINDOWS_CCONV unsafe "windows.h ReadFile"
   c_ReadFile :: HANDLE -> Ptr a -> DWORD -> Ptr DWORD -> LPOVERLAPPED -> IO Bool
 
 -- | Writes data to a file or input/output (I/O) device.
---------------------------------------------------------------------------------
--- Writes data from a buffer to the specified file or input/output device.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] hFile
--- A handle to the file or I/O device to be written to.
---------------------------------------------------------------------------------
--- [in] lpBuffer
--- A pointer to the buffer containing the data to be written.
---------------------------------------------------------------------------------
--- [in] nNumberOfBytesToWrite
--- The number of bytes to be written.
---------------------------------------------------------------------------------
--- [out, optional] lpNumberOfBytesWritten
--- A pointer to the variable that receives the number of bytes written.
---------------------------------------------------------------------------------
--- [in, optional] lpOverlapped
--- A pointer to an OVERLAPPED structure for asynchronous operations. Can be NULL
--- for synchronous operations.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
+-- Possible errors:
+-- ERROR_ACCESS_DENIED             5   (0x5)
+-- ERROR_INVALID_HANDLE            6   (0x6)
+-- ERROR_HANDLE_EOF               38   (0x26)
+-- ERROR_BROKEN_PIPE             109   (0x6D)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+-- ERROR_DISK_FULL               112   (0x70)
+-- ERROR_IO_PENDING              997   (0x3E5)
 --
--- ERROR_IO_PENDING        997 (0x3E5)
--- An overlapped I/O operation is in progress.
---------------------------------------------------------------------------------
--- link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-writefile
 foreign import WINDOWS_CCONV unsafe "windows.h WriteFile"
   c_WriteFile :: HANDLE -> Ptr a -> DWORD -> Ptr DWORD -> LPOVERLAPPED -> IO Bool
 
 -- | Moves the file pointer of an open file.
---------------------------------------------------------------------------------
--- Sets the file pointer for the specified file to a new position, which can be
--- specified as an offset from the beginning, current position, or end of the file.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] hFile
--- A handle to the file whose file pointer is to be moved.
---------------------------------------------------------------------------------
--- [in] liDistanceToMove
--- The number of bytes to move the file pointer.
---------------------------------------------------------------------------------
--- [out, optional] lpNewFilePointer
--- A pointer to a variable that receives the new file pointer value. Can be NULL.
---------------------------------------------------------------------------------
--- [in] dwMoveMethod
--- The starting point for the file pointer move (see FilePtrDirection).
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
+-- Possible errors:
+-- ERROR_INVALID_HANDLE            6   (0x6)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+-- ERROR_NEGATIVE_SEEK           131   (0x83)
 --
--- ERROR_INVALID_PARAMETER 87  (0x57)
--- One or more parameters are invalid.
---------------------------------------------------------------------------------
--- link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfilepointerex
 foreign import WINDOWS_CCONV unsafe "windows.h SetFilePointerEx"
   c_SetFilePointerEx :: HANDLE -> LARGE_INTEGER -> Ptr LARGE_INTEGER -> FilePtrDirection -> IO Bool
@@ -1391,76 +1021,30 @@ foreign import WINDOWS_CCONV unsafe "windows.h SetFilePointerEx"
 ----------------------------------------------------------------
 
 -- | Creates a change notification handle and sets up initial change notification filter conditions.
---------------------------------------------------------------------------------
--- Creates a handle that can be used to monitor a directory or subtree for
--- changes such as file creation, deletion, or modification.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] lpPathName
--- The path of the directory to be monitored.
---------------------------------------------------------------------------------
--- [in] bWatchSubtree
--- If TRUE, the function monitors the directory tree rooted at the specified
--- directory; if FALSE, it monitors only the specified directory.
---------------------------------------------------------------------------------
--- [in] dwNotifyFilter
--- The filter conditions that satisfy a change notification wait. This parameter
--- can be one or more FileNotificationFlag values.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is a handle to the change
--- notification object. If the function fails, the return value is
--- INVALID_HANDLE_VALUE.
+-- Possible errors:
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+-- ERROR_PATH_NOT_FOUND            3   (0x3)
+-- ERROR_ACCESS_DENIED             5   (0x5)
 --
--- ERROR_INVALID_PARAMETER   87  (0x57)
--- One or more parameters are invalid.
---------------------------------------------------------------------------------
--- link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstchangenotificationw
 foreign import WINDOWS_CCONV unsafe "windows.h FindFirstChangeNotificationW"
   c_FindFirstChangeNotification :: LPCTSTR -> Bool -> FileNotificationFlag -> IO HANDLE
 
 -- | Requests that the operating system signal a change notification handle when a change occurs.
---------------------------------------------------------------------------------
--- Continues monitoring a directory or subtree for changes after a previous
--- change notification has been received.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] hChangeHandle
--- A handle to a change notification object returned by FindFirstChangeNotificationW.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
---
+-- Possible errors:
 -- ERROR_INVALID_HANDLE    6   (0x6)
--- The handle is invalid.
---------------------------------------------------------------------------------
--- link to original documentation:
+--
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findnextchangenotification
 foreign import WINDOWS_CCONV unsafe "windows.h FindNextChangeNotification"
   c_FindNextChangeNotification :: HANDLE -> IO Bool
 
 -- | Closes a change notification handle.
---------------------------------------------------------------------------------
--- Closes a handle created by FindFirstChangeNotificationW and releases any
--- associated resources.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] hChangeHandle
--- A handle to a change notification object returned by FindFirstChangeNotificationW.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
---
+-- Possible errors:
 -- ERROR_INVALID_HANDLE    6   (0x6)
--- The handle is invalid.
---------------------------------------------------------------------------------
--- link to original documentation:
+--
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findclosechangenotification
 foreign import WINDOWS_CCONV unsafe "windows.h FindCloseChangeNotification"
   c_FindCloseChangeNotification :: HANDLE -> IO Bool
@@ -1474,75 +1058,35 @@ type WIN32_FIND_DATA = ()
 newtype FindData = FindData (ForeignPtr WIN32_FIND_DATA)
 
 -- | Searches a directory for a file or subdirectory with a name that matches a specified pattern.
---------------------------------------------------------------------------------
--- Begins a file search in a directory, returning information about the first
--- file or subdirectory found that matches the specified pattern.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] lpFileName
--- The directory or path, and the file name, which can include wildcard
--- characters (* and ?).
---------------------------------------------------------------------------------
--- [out] lpFindFileData
--- A pointer to a WIN32_FIND_DATA structure that receives information about the
--- found file or directory.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is a search handle used in
--- subsequent calls to FindNextFile or FindClose. If the function fails, the
--- return value is INVALID_HANDLE_VALUE.
---------------------------------------------------------------------------------
--- link to original documentation:
+-- Possible errors:
+-- ERROR_FILE_NOT_FOUND            2   (0x2)
+-- ERROR_PATH_NOT_FOUND            3   (0x3)
+-- ERROR_ACCESS_DENIED             5   (0x5)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+-- ERROR_INVALID_HANDLE            6   (0x6)
+--
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstfilew
 foreign import WINDOWS_CCONV unsafe "windows.h FindFirstFileW"
   c_FindFirstFile :: LPCTSTR -> Ptr WIN32_FIND_DATA -> IO HANDLE
 
 -- | Continues a file search from a previous call to FindFirstFileW.
---------------------------------------------------------------------------------
--- Retrieves information about the next file or directory that matches the
--- search criteria specified in a previous call to FindFirstFileW.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] hFindFile
--- The search handle returned by a previous call to FindFirstFileW.
---------------------------------------------------------------------------------
--- [out] lpFindFileData
--- A pointer to a WIN32_FIND_DATA structure that receives information about the
--- found file or directory.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero, and no more files are found
--- or an error occurred.
+-- Possible errors:
+-- ERROR_NO_MORE_FILES            18   (0x12)
+-- ERROR_INVALID_HANDLE            6   (0x6)
+-- ERROR_ACCESS_DENIED             5   (0x5)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
 --
--- ERROR_NO_MORE_FILES      18  (0x12)
--- No more files were found.
---------------------------------------------------------------------------------
--- link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findnextfilew
 foreign import WINDOWS_CCONV unsafe "windows.h FindNextFileW"
   c_FindNextFile :: HANDLE -> Ptr WIN32_FIND_DATA -> IO BOOL
 
 -- | Closes a file search handle.
---------------------------------------------------------------------------------
--- Closes a search handle opened by FindFirstFileW or FindNextFileW and releases
--- any associated resources.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] hFindFile
--- The search handle returned by FindFirstFileW.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
---
+-- Possible errors:
 -- ERROR_INVALID_HANDLE    6   (0x6)
--- The handle is invalid.
---------------------------------------------------------------------------------
--- link to original documentation:
+--
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findclose
 foreign import WINDOWS_CCONV unsafe "windows.h FindClose"
   c_FindClose :: HANDLE -> IO BOOL
@@ -1552,30 +1096,12 @@ foreign import WINDOWS_CCONV unsafe "windows.h FindClose"
 ----------------------------------------------------------------
 
 -- | Defines, modifies, or deletes MS-DOS device names.
---------------------------------------------------------------------------------
--- Creates, modifies, or deletes a symbolic link for a DOS device name.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] dwFlags
--- Control flags that specify the function's behavior. This parameter can be a
--- combination of DefineDosDeviceFlags values.
---------------------------------------------------------------------------------
--- [in] lpDeviceName
--- The device name string (for example, "COM1").
---------------------------------------------------------------------------------
--- [in, optional] lpTargetPath
--- The path to which the device name refers. This can be NULL when removing a
--- definition.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
+-- Possible errors:
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+-- ERROR_ACCESS_DENIED             5   (0x5)
+-- ERROR_FILE_NOT_FOUND            2   (0x2)
 --
--- ERROR_INVALID_PARAMETER   87  (0x57)
--- One or more parameters are invalid.
---------------------------------------------------------------------------------
--- link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-definedosdevicew
 foreign import WINDOWS_CCONV unsafe "windows.h DefineDosDeviceW"
   c_DefineDosDevice :: DefineDosDeviceFlags -> LPCTSTR -> LPCTSTR -> IO Bool
@@ -1586,53 +1112,37 @@ foreign import WINDOWS_CCONV unsafe "windows.h DefineDosDeviceW"
 -- They don't return error codes
 
 -- | Determines whether the file I/O functions are using the ANSI or OEM character set.
---------------------------------------------------------------------------------
--- Indicates whether the file APIs are set to use the ANSI character set or the
--- OEM character set for file names and other string parameters.
 --
--- Return value
--- If the function succeeds, the return value is nonzero if the file APIs are
--- using the ANSI character set, or zero if they are using the OEM character set.
---------------------------------------------------------------------------------
--- link to original documentation:
+-- Possible errors:
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+--
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-arefileapisansi
 foreign import WINDOWS_CCONV unsafe "windows.h AreFileApisANSI"
   areFileApisANSI :: IO Bool
 
 -- | Sets the file I/O functions to use the OEM character set.
---------------------------------------------------------------------------------
--- Configures the file APIs to use the OEM character set for file names and
--- other string parameters instead of the ANSI character set.
---------------------------------------------------------------------------------
--- link to original documentation:
+--
+-- Possible errors:
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+--
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfileapistooem
 foreign import WINDOWS_CCONV unsafe "windows.h SetFileApisToOEM"
   setFileApisToOEM :: IO ()
 
 -- | Sets the file I/O functions to use the ANSI character set.
---------------------------------------------------------------------------------
--- Configures the file APIs to use the ANSI character set for file names and
--- other string parameters instead of the OEM character set.
---------------------------------------------------------------------------------
--- link to original documentation:
+--
+-- Possible errors:
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+--
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfileapistoansi
 foreign import WINDOWS_CCONV unsafe "windows.h SetFileApisToANSI"
   setFileApisToANSI :: IO ()
 
 -- | Sets the maximum number of files that a process can have open simultaneously.
---------------------------------------------------------------------------------
--- Sets the size of the per-process file handle table, which determines the
--- maximum number of files that the process can have open at the same time.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] uNumber
--- The maximum number of open file handles for the process.
---------------------------------------------------------------------------------
--- Return value
--- The return value is the previous maximum number of open file handles.
---------------------------------------------------------------------------------
--- link to original documentation:
+-- Possible errors:
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+--
 -- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-sethandlecount
 foreign import WINDOWS_CCONV unsafe "windows.h SetHandleCount"
   setHandleCount :: UINT -> IO UINT
@@ -1640,78 +1150,35 @@ foreign import WINDOWS_CCONV unsafe "windows.h SetHandleCount"
 ----------------------------------------------------------------
 
 -- | Retrieves a bitmask representing the currently available disk drives.
---------------------------------------------------------------------------------
--- Returns a bitmask in which each bit represents one logical drive present on
--- the system.
 --
--- Return value
--- If the function succeeds, the return value is a bitmask representing the
--- currently available disk drives. If the function fails, the return value is
--- zero.
---------------------------------------------------------------------------------
--- link to original documentation:
+-- Possible errors:
+-- ERROR_INVALID_FUNCTION          1   (0x1)
+--
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getlogicaldrives
 foreign import WINDOWS_CCONV unsafe "windows.h GetLogicalDrives"
   c_GetLogicalDrives :: IO DWORD
 
 -- | Retrieves information about the amount of free and total space on a disk.
---------------------------------------------------------------------------------
--- Retrieves information about the specified disk, including the number of
--- sectors per cluster, bytes per sector, number of free clusters, and total
--- number of clusters.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] lpRootPathName
--- The root directory of the disk to return information about (for example,
--- "C:\").
---------------------------------------------------------------------------------
--- [out] lpSectorsPerCluster
--- A pointer to a variable that receives the number of sectors per cluster.
---------------------------------------------------------------------------------
--- [out] lpBytesPerSector
--- A pointer to a variable that receives the number of bytes per sector.
---------------------------------------------------------------------------------
--- [out] lpNumberOfFreeClusters
--- A pointer to a variable that receives the total number of free clusters on
--- the disk.
---------------------------------------------------------------------------------
--- [out] lpTotalNumberOfClusters
--- A pointer to a variable that receives the total number of clusters on the
--- disk.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
+-- Possible errors:
+-- ERROR_INVALID_FUNCTION          1   (0x1)
+-- ERROR_PATH_NOT_FOUND            3   (0x3)
+-- ERROR_ACCESS_DENIED             5   (0x5)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
 --
--- ERROR_INVALID_PARAMETER   87  (0x57)
--- One or more parameters are invalid.
---------------------------------------------------------------------------------
--- link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getdiskfreespacew
 foreign import WINDOWS_CCONV unsafe "windows.h GetDiskFreeSpaceW"
   c_GetDiskFreeSpace :: LPCTSTR -> Ptr DWORD -> Ptr DWORD -> Ptr DWORD -> Ptr DWORD -> IO Bool
 
 -- | Sets the volume label for a specified disk volume.
---------------------------------------------------------------------------------
--- Assigns a new label to a disk volume.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] lpRootPathName
--- The root directory of the volume to be labeled (for example, "C:\").
---------------------------------------------------------------------------------
--- [in, optional] lpVolumeName
--- The new label for the volume. If this parameter is NULL, the label is deleted.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
+-- Possible errors:
+-- ERROR_ACCESS_DENIED             5   (0x5)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
+-- ERROR_LABEL_TOO_LONG          154   (0x9A)
+-- ERROR_INVALID_NAME            123   (0x7B)
+-- ERROR_DIRECTORY               267   (0x10B)
 --
--- ERROR_INVALID_PARAMETER   87  (0x57)
--- One or more parameters are invalid.
---------------------------------------------------------------------------------
--- link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setvolumelabelw
 foreign import WINDOWS_CCONV unsafe "windows.h SetVolumeLabelW"
   c_SetVolumeLabel :: LPCTSTR -> LPCTSTR -> IO Bool
@@ -1721,76 +1188,25 @@ foreign import WINDOWS_CCONV unsafe "windows.h SetVolumeLabelW"
 ----------------------------------------------------------------
 
 -- | Locks a region of a file for exclusive or shared access.
---------------------------------------------------------------------------------
--- Locks a specified region of a file, preventing access by other processes
--- depending on the requested lock mode.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] hFile
--- A handle to the file to be locked.
---------------------------------------------------------------------------------
--- [in] dwFlags
--- Specifies the lock mode. This parameter can be a combination of LockMode
--- values.
---------------------------------------------------------------------------------
--- [in] dwReserved
--- Reserved; must be zero.
---------------------------------------------------------------------------------
--- [in] nNumberOfBytesToLockLow
--- The low-order part of the length of the byte range to lock.
---------------------------------------------------------------------------------
--- [in] nNumberOfBytesToLockHigh
--- The high-order part of the length of the byte range to lock.
---------------------------------------------------------------------------------
--- [in, out] lpOverlapped
--- A pointer to an OVERLAPPED structure that specifies the starting offset of
--- the lock.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
+-- Possible errors:
+-- ERROR_INVALID_HANDLE            6   (0x6)
+-- ERROR_LOCK_VIOLATION           33   (0x21)
+-- ERROR_NOT_ENOUGH_MEMORY        8    (0x8)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
 --
--- ERROR_LOCK_VIOLATION     33  (0x21)
--- The process cannot access the file because another process has locked a
--- portion of the file.
---------------------------------------------------------------------------------
--- link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex
 foreign import WINDOWS_CCONV unsafe "LockFileEx"
   c_LockFileEx :: HANDLE -> DWORD -> DWORD -> DWORD -> DWORD -> LPOVERLAPPED
                -> IO BOOL
 
 -- | Unlocks a region of a file previously locked by LockFileEx.
---------------------------------------------------------------------------------
--- Unlocks a specified region of a file, allowing access by other processes.
 --
--- Parameters:
---------------------------------------------------------------------------------
--- [in] hFile
--- A handle to the file to be unlocked.
---------------------------------------------------------------------------------
--- [in] dwReserved
--- Reserved; must be zero.
---------------------------------------------------------------------------------
--- [in] nNumberOfBytesToUnlockLow
--- The low-order part of the length of the byte range to unlock.
---------------------------------------------------------------------------------
--- [in] nNumberOfBytesToUnlockHigh
--- The high-order part of the length of the byte range to unlock.
---------------------------------------------------------------------------------
--- [in, out] lpOverlapped
--- A pointer to an OVERLAPPED structure that specifies the starting offset of
--- the unlock.
---------------------------------------------------------------------------------
--- Return value
--- If the function succeeds, the return value is nonzero.
--- If the function fails, the return value is zero.
+-- Possible errors:
+-- ERROR_INVALID_HANDLE            6   (0x6)
+-- ERROR_NOT_LOCKED              158   (0x9E)
+-- ERROR_INVALID_PARAMETER        87   (0x57)
 --
--- ERROR_NOT_LOCKED         158 (0x9E)
--- The region specified is not locked by the calling process.
---------------------------------------------------------------------------------
--- link to original documentation:
 -- https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-unlockfileex
 foreign import WINDOWS_CCONV unsafe "UnlockFileEx"
   c_UnlockFileEx :: HANDLE -> DWORD -> DWORD -> DWORD -> LPOVERLAPPED -> IO BOOL


### PR DESCRIPTION
## Description
I want to document the entire repository.
I think this pull request is a good starting point to start writing documentation.

## Motivation and Context
I want to add documentation because:
1) want to know what errors the function throws.
2) want to know if it is atomic, and if not, how it is violated.
3) want to add basic documentation.
4) want to reimplement this in packages above like `directory`, `cabal`, `file-io` and so on.

## Types of changes
- [X] Add more docs

## Checklist:
- [X] Changes to a uniform style are possible.
- [X] Updated the documentation accordingly.
